### PR TITLE
Home card db

### DIFF
--- a/app/src/main/java/com/example/karaoke_note/Home.kt
+++ b/app/src/main/java/com/example/karaoke_note/Home.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -26,12 +27,85 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import com.example.karaoke_note.data.Song
+import com.example.karaoke_note.data.SongDao
+import com.example.karaoke_note.data.SongScore
+import com.example.karaoke_note.data.SongScoreDao
+import java.time.LocalDate
+
+private fun loadDummyData(songDao: SongDao, songScoreDao: SongScoreDao) {
+    val songId1 = songDao.insertSong(
+        Song(
+            title = "長いタイトル長いタイトル長いタイトル長いタイトル",
+            artist = "長いアーティスト長いアーティスト長いアーティスト長いアーティスト"
+        )
+    )
+    songScoreDao.insertSongScore(
+        SongScore(
+            songId = songId1,
+            date = LocalDate.parse("1996-08-17"),
+            score = 98.76543f,
+            key = -6,
+            comment = "テストテスト"
+        )
+    )
+
+    val songId2 = songDao.insertSong(Song(title = "1 2 3 ~恋が始まる~", artist = "いきものがかり"))
+    songScoreDao.insertSongScore(
+        SongScore(
+            songId = songId2,
+            date = LocalDate.parse("2023-06-24"),
+            score = 100.000f,
+            key = -2,
+            comment = ""
+        )
+    )
+    val songId3 = songDao.insertSong(Song(title = "ARIA", artist = "Kalafina"))
+    songScoreDao.insertSongScore(
+        SongScore(
+            songId = songId3,
+            date = LocalDate.parse("2023-06-24"),
+            score = 90.672f,
+            key = -1,
+            comment = "-1で試す。"
+        )
+    )
+    val songId4 = songDao.insertSong(Song(title = "星月夜", artist = "由薫"))
+    songScoreDao.insertSongScore(
+        SongScore(
+            songId = songId4,
+            date = LocalDate.parse("2023-06-24"),
+            score = 90.919f,
+            key = -3,
+            comment = ""
+        )
+    )
+    songScoreDao.insertSongScore(
+        SongScore(
+            songId = songId4,
+            date = LocalDate.parse("2023-06-24"),
+            score = 90.920f,
+            key = -3,
+            comment = ""
+        )
+    )
+    songScoreDao.insertSongScore(
+        SongScore(
+            songId = songId4,
+            date = LocalDate.parse("2023-06-24"),
+            score = 90.921f,
+            key = -3,
+            comment = ""
+        )
+    )
+}
 
 @ExperimentalMaterial3Api
 @Composable
-fun Home(navController: NavController) {
+fun Home(navController: NavController, songDao: SongDao, songScoreDao: SongScoreDao) {
+    loadDummyData(songDao, songScoreDao)
     Column {
-        Box(modifier = Modifier.weight(1f)){
+        Box(modifier = Modifier.weight(1f)) {
             Button(onClick = { navController.navigate("song_data") }) {
                 Text("Navigate to song_data")
             }
@@ -40,44 +114,14 @@ fun Home(navController: NavController) {
             LazyColumn(
                 modifier = Modifier
             ) {
-                item {
-                    LatestCard(
-                        date = "1996/08/17",
-                        title = "長いタイトル長いタイトル長いタイトル長いタイトル",
-                        artist = "長いアーティスト長いアーティスト長いアーティスト長いアーティスト",
-                        score = 98.76543,
-                        key = -6,
-                        comment = "テストテスト"
-                    )
-                }
-                item {
-                    LatestCard(
-                        date = "2023/06/24",
-                        title = "1 2 3 ~恋が始まる~",
-                        artist = "いきものがかり",
-                        score = 100.000,
-                        key = -2,
-                        comment = ""
-                    )
-                }
-                item {
-                    LatestCard(
-                        date = "2023/06/24",
-                        title = "ARIA",
-                        artist = "Kalafina",
-                        score = 90.672,
-                        key = -1,
-                        comment = "-1で試す。"
-                    )
-                }
-                items(5) {
-                    LatestCard(
-                        date = "2023/06/24",
-                        title = "星月夜",
-                        artist = "由薫",
-                        score = 90.919,
-                        key = -3,
-                    )
+                val songDataList = songScoreDao.getLatestScores(10)
+                items(songDataList) { songData ->
+                    val song = songDao.getSong(songData.songId)
+                    if (song != null) {
+                        LatestCard(song = song, songScore = songData)
+                    } else {
+                        // データベースが壊れている
+                    }
                 }
             }
         }
@@ -89,10 +133,10 @@ fun Home(navController: NavController) {
 
 @ExperimentalMaterial3Api
 @Composable
-fun LatestCard(date: String, title: String, artist: String, score: Double, key: Int, comment: String = "") {
+fun LatestCard(song: Song, songScore: SongScore) {
     remember { mutableStateOf(false) }
     var commentforcard = ""
-    if (comment.isNotEmpty()) {
+    if (songScore.comment.isNotEmpty()) {
         commentforcard = "..."
     }
 
@@ -124,7 +168,7 @@ fun LatestCard(date: String, title: String, artist: String, score: Double, key: 
                         verticalArrangement = Arrangement.SpaceBetween
                     ){
                         Text(
-                            text = date,
+                            text = songScore.date.toString(),
                             modifier = Modifier
                                 .padding(start = 16.dp, top = 8.dp, bottom = 8.dp)
                                 .align(Alignment.Start),
@@ -133,7 +177,7 @@ fun LatestCard(date: String, title: String, artist: String, score: Double, key: 
                             fontSize = 6.sp,
                         )
                         Text(
-                            text = title,
+                            text = song.title,
                             modifier = Modifier
                                 .padding(start = 20.dp, top = 4.dp, bottom = 4.dp)
                                 .align(Alignment.Start),
@@ -144,7 +188,7 @@ fun LatestCard(date: String, title: String, artist: String, score: Double, key: 
                             overflow = TextOverflow.Ellipsis,
                         )
                         Text(
-                            text = artist,
+                            text = song.artist,
                             modifier = Modifier
                                 .padding(start = 20.dp, top = 4.dp, bottom = 4.dp)
                                 .align(Alignment.Start),
@@ -168,7 +212,7 @@ fun LatestCard(date: String, title: String, artist: String, score: Double, key: 
                         verticalArrangement = Arrangement.SpaceBetween
                     ) {
                         Text(
-                            text = String.format("%.3f", score),
+                            text = String.format("%.3f", songScore.score),
                             modifier = Modifier
                                 .padding(top = 0.dp, end = 16.dp, bottom = 2.dp)
                                 .align(Alignment.End),
@@ -177,7 +221,7 @@ fun LatestCard(date: String, title: String, artist: String, score: Double, key: 
                             fontSize = 12.sp,
                         )
                         Text(
-                            text = key.toString(),
+                            text = songScore.key.toString(),
                             modifier = Modifier
                                 .padding(top = 2.dp, end = 16.dp, bottom = 2.dp)
                                 .align(Alignment.End),

--- a/app/src/main/java/com/example/karaoke_note/Home.kt
+++ b/app/src/main/java/com/example/karaoke_note/Home.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -105,11 +104,6 @@ private fun loadDummyData(songDao: SongDao, songScoreDao: SongScoreDao) {
 fun Home(navController: NavController, songDao: SongDao, songScoreDao: SongScoreDao) {
     loadDummyData(songDao, songScoreDao)
     Column {
-        Box(modifier = Modifier.weight(1f)) {
-            Button(onClick = { navController.navigate("song_data") }) {
-                Text("Navigate to song_data")
-            }
-        }
         Box(modifier = Modifier.weight(8f)) {
             LazyColumn(
                 modifier = Modifier
@@ -118,7 +112,7 @@ fun Home(navController: NavController, songDao: SongDao, songScoreDao: SongScore
                 items(songDataList) { songData ->
                     val song = songDao.getSong(songData.songId)
                     if (song != null) {
-                        LatestCard(song = song, songScore = songData)
+                        LatestCard(song, songData, navController)
                     } else {
                         // データベースが壊れている
                     }
@@ -133,7 +127,7 @@ fun Home(navController: NavController, songDao: SongDao, songScoreDao: SongScore
 
 @ExperimentalMaterial3Api
 @Composable
-fun LatestCard(song: Song, songScore: SongScore) {
+fun LatestCard(song: Song, songScore: SongScore, navController: NavController) {
     remember { mutableStateOf(false) }
     var commentforcard = ""
     if (songScore.comment.isNotEmpty()) {
@@ -145,7 +139,7 @@ fun LatestCard(song: Song, songScore: SongScore) {
             .padding(horizontal = 20.dp, vertical = 12.dp)
     ) {
         Card(
-            onClick = { },
+            onClick = {navController.navigate("song_data/${song.id}")},
             shape = MaterialTheme.shapes.medium,
             modifier = Modifier
                 .fillMaxWidth(),

--- a/app/src/main/java/com/example/karaoke_note/MainActivity.kt
+++ b/app/src/main/java/com/example/karaoke_note/MainActivity.kt
@@ -14,7 +14,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.example.karaoke_note.data.AppDatabase
-import com.example.karaoke_note.data.Song
 import com.example.karaoke_note.ui.theme.Karaoke_noteTheme
 
 class MainActivity : ComponentActivity() {
@@ -24,7 +23,6 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         val songDao = AppDatabase.getDatabase(this).songDao()
         val songScoreDao = AppDatabase.getDatabase(this).songScoreDao()
-        val context = this
         setContent {
             Karaoke_noteTheme {
                 // A surface container using the 'background' color from the theme
@@ -46,9 +44,14 @@ class MainActivity : ComponentActivity() {
                             composable("home") {
                                 Home(navController, songDao, songScoreDao)
                             }
-                            composable("song_data") {
-                                val songId = songDao.insertSong(Song(title = "Song1", artist = "Artist1"))
-                                SongScores(Song(id = songId, title = "Song1", artist = "Artist1"), context)
+                            composable("song_data/{songId}") {backStackEntry ->
+                                val songId = backStackEntry.arguments?.getString("songId")?.toLongOrNull()
+                                if (songId != null) {
+                                    val song = songDao.getSong(songId)
+                                    if (song != null) {
+                                        SongScores(song, songScoreDao)
+                                    }
+                                }
                             }
                             composable("list"){
                                 ArtistsPage(navController, "artist")

--- a/app/src/main/java/com/example/karaoke_note/MainActivity.kt
+++ b/app/src/main/java/com/example/karaoke_note/MainActivity.kt
@@ -23,6 +23,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val songDao = AppDatabase.getDatabase(this).songDao()
+        val songScoreDao = AppDatabase.getDatabase(this).songScoreDao()
         val context = this
         setContent {
             Karaoke_noteTheme {
@@ -43,7 +44,7 @@ class MainActivity : ComponentActivity() {
                             Modifier.padding(paddingValues)
                         ) {
                             composable("home") {
-                                Home(navController)
+                                Home(navController, songDao, songScoreDao)
                             }
                             composable("song_data") {
                                 val songId = songDao.insertSong(Song(title = "Song1", artist = "Artist1"))

--- a/app/src/main/java/com/example/karaoke_note/SongScores.kt
+++ b/app/src/main/java/com/example/karaoke_note/SongScores.kt
@@ -1,6 +1,5 @@
 package com.example.karaoke_note
 
-import android.content.Context
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,7 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.example.karaoke_note.data.AppDatabase
 import com.example.karaoke_note.data.Song
 import com.example.karaoke_note.data.SongScore
 import com.example.karaoke_note.data.SongScoreDao
@@ -45,8 +43,7 @@ enum class SortDirection {
 }
 
 @Composable
-fun SongScores(song: Song, context: Context) {
-    val songScoreDao = AppDatabase.getDatabase(context).songScoreDao()
+fun SongScores(song: Song, songScoreDao: SongScoreDao) {
     val scoresFlow = songScoreDao.getScoresForSong(song.id)
     val scores by scoresFlow.collectAsState(initial = emptyList())
     Column {

--- a/app/src/main/java/com/example/karaoke_note/data/SongDao.kt
+++ b/app/src/main/java/com/example/karaoke_note/data/SongDao.kt
@@ -16,6 +16,9 @@ interface SongDao {
     @Query("SELECT * FROM Song WHERE title = :title AND artist = :artist LIMIT 1")
     fun getSong(title: String, artist: String): Song?
 
+    @Query("SELECT * FROM Song WHERE id = :id")
+    fun getSong(id: Long): Song?
+
     @Transaction
     fun insertSong(song: Song): Long {
         return getSongId(song.title, song.artist) ?: insertUniqueSong(song)

--- a/app/src/main/java/com/example/karaoke_note/data/SongScoreDao.kt
+++ b/app/src/main/java/com/example/karaoke_note/data/SongScoreDao.kt
@@ -3,20 +3,40 @@ package com.example.karaoke_note.data
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
 
 @Dao
 interface SongScoreDao {
     @Query("SELECT * FROM SongScore WHERE songId = :songId")
     fun getScoresForSong(songId: Long): Flow<List<SongScore>>
 
-    @Query("SELECT * FROM SongScore ORDER BY date DESC LIMIT 5")
-    fun getLatestScores(): List<SongScore>
+    @Query("SELECT * FROM SongScore ORDER BY date DESC LIMIT :limit")
+    fun getLatestScores(limit: Int): List<SongScore>
+
+    @Query("SELECT * FROM SongScore WHERE songId = :songId AND date = :date AND score = :score AND \"key\" = :key AND comment = :comment")
+    fun findSongScore(songId: Long, date: LocalDate, score: Float, key: Int, comment: String): SongScore?
+
+    @Transaction
+    fun insertSongScore(score: SongScore) {
+        val existingEntry = findSongScore(
+            score.songId,
+            score.date,
+            score.score,
+            score.key,
+            score.comment
+        )
+        if (existingEntry == null) {
+            insertUniqueSongScore(score)
+        }
+    }
 
     @Insert
-    fun insertSongScore(score: SongScore)
+    fun insertUniqueSongScore(songScore: SongScore)
 
     @Query("DELETE FROM SongScore WHERE id = :id")
     fun deleteSongScore(id: Long)
+
 
 }


### PR DESCRIPTION
Homeのカードから曲ごとのスコアに遷移するための変更です。
ダミーデータは毎回勝手に追加するようにし、重複したデータは実際にはデータベースに登録しないことにしました。