### PR TITLE
DAM の精密採点 DX ミリオンは 100 点満点ではないため削除した。

### DIFF
--- a/app/src/main/java/com/example/karaoke_note/data/GameKind.kt
+++ b/app/src/main/java/com/example/karaoke_note/data/GameKind.kt
@@ -7,7 +7,6 @@ enum class GameKind(val displayName: String) {
     JOY_ANALYSIS_SCORING_MASTER("[JOY] 分析採点マスター"),
     DAM_RANKING_BATTLE_ONLINE("[DAM] ランキングバトルONLINE"),
     DAM_PRECISE_SCORING_AI("[DAM] 精密採点Ai"),
-    DAM_PRECISE_SCORING_DX_MILLION("[DAM] 精密採点DXミリオン"),
     DAM_PRECISE_SCORING_DX_G("[DAM] 精密採点DX-G"),
     DAM_PRECISE_SCORING_DX_DUET("[DAM] 精密採点DXデュエット"),
     DAM_PRECISE_SCORING_DX("[DAM] 精密採点DX");


### PR DESCRIPTION
ミリオンを選択したときだけスコア欄のフォーマットを変えるという手もあるかもしれない。