### PR TITLE
スコア編集時に削除->追加ではなく更新するよう変更

### DIFF
--- a/app/src/main/java/com/example/karaoke_note/data/SongScoreDao.kt
+++ b/app/src/main/java/com/example/karaoke_note/data/SongScoreDao.kt
@@ -4,7 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import androidx.room.Transaction
+import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
 import java.time.LocalDate
 
@@ -35,23 +35,11 @@ interface SongScoreDao {
     """)
     fun getMostRecentDate(songId: Long): LocalDate?
 
-    @Transaction
-    fun insertSongScore(score: SongScore) {
-        val existingEntry = findSongScore(
-            score.songId,
-            score.date,
-            score.score,
-            score.key,
-            score.comment,
-            score.gameKind
-        )
-        if (existingEntry == null) {
-            insertUniqueSongScore(score)
-        }
-    }
+    @Update
+    fun update(songScore: SongScore): Int
 
     @Insert
-    fun insertUniqueSongScore(songScore: SongScore)
+    fun insert(songScore: SongScore)
 
     @Query("DELETE FROM SongScore WHERE id = :id")
     fun deleteSongScore(id: Long)


### PR DESCRIPTION
#78 の修正です。
非同期に削除してから追加すると問題が起きるようなので、削除ではなく更新するようにします。