### PR TITLE
新規登録画面を戻るボタンを押して終了させると編集モードを解除できない問題を修正。

### DIFF
--- a/app/src/main/java/com/example/karaoke_note/NewEntrySheet.kt
+++ b/app/src/main/java/com/example/karaoke_note/NewEntrySheet.kt
@@ -111,7 +111,6 @@ fun CommonTextField(
         }
     }
 
-
     OutlinedTextField(
         value = textFieldValue,
         onValueChange = { changed ->
@@ -457,7 +456,10 @@ fun NewEntryScreen(navController: NavController, songDao: SongDao, songScoreDao:
 
     if (screenOpened.value) {
         Dialog(
-            onDismissRequest = { screenOpened.value = false },
+            onDismissRequest = {
+                screenOpened.value = false
+                editingSongScoreState.value = null
+            },
             properties = DialogProperties(usePlatformDefaultWidth = false)
         ) {
             Surface(


### PR DESCRIPTION
#87 です。