### PR TITLE
点数が0のスコアとそうでないスコアを区別するようDBのクエリを変更

### DIFF
--- a/app/src/main/java/com/example/karaoke_note/Plans.kt
+++ b/app/src/main/java/com/example/karaoke_note/Plans.kt
@@ -41,7 +41,7 @@ fun PlansPage(navController: NavController, songDao: SongDao, songScoreDao: Song
             LazyColumn(
                 modifier = Modifier
             ) {
-                val songDataList = songScoreDao.getLatestScores(10)
+                val songDataList = songScoreDao.getAll0Scores()
                 items(songDataList) { songData ->
                     val song = songDao.getSong(songData.songId)
                     if (song != null) {

--- a/app/src/main/java/com/example/karaoke_note/data/SongDao.kt
+++ b/app/src/main/java/com/example/karaoke_note/data/SongDao.kt
@@ -44,6 +44,6 @@ interface SongDao {
     @Query("DELETE FROM Song")
     fun clearAllSongs()
 
-    @Query("SELECT Song.* FROM Song INNER JOIN SongScore ON Song.id = SongScore.songId WHERE Song.artistId = :artistId GROUP BY Song.id")
+    @Query("SELECT Song.* FROM Song INNER JOIN SongScore ON Song.id = SongScore.songId WHERE Song.artistId = :artistId AND SongScore.score != 0.0 GROUP BY Song.id")
     fun getSongsWithScores(artistId: Long): Flow<List<Song>>
 }

--- a/app/src/main/java/com/example/karaoke_note/data/SongScoreDao.kt
+++ b/app/src/main/java/com/example/karaoke_note/data/SongScoreDao.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 
 @Dao
 interface SongScoreDao {
-    @Query("SELECT * FROM SongScore WHERE songId = :songId")
+    @Query("SELECT * FROM SongScore WHERE songId = :songId AND score != 0.0")
     fun getScoresForSong(songId: Long): Flow<List<SongScore>>
 
     @Query("SELECT * FROM SongScore ORDER BY date DESC, id DESC LIMIT :limit")
@@ -55,4 +55,7 @@ interface SongScoreDao {
 
     @Query("DELETE FROM SongScore")
     fun clearAllSongScores()
+
+    @Query("SELECT * FROM SongScore WHERE score = 0.0")
+    fun getAll0Scores(): List<SongScore>
 }


### PR DESCRIPTION
#34 の一環。
点数が0のスコアを取得するクエリを追加し、既存のクエリは点数が0のものを含まないようにします。