### PR TITLE
Plansページからスコア登録画面を開く

### DIFF
--- a/app/src/main/java/com/example/karaoke_note/MainActivity.kt
+++ b/app/src/main/java/com/example/karaoke_note/MainActivity.kt
@@ -82,7 +82,7 @@ class MainActivity : ComponentActivity() {
                                 }
                             }
                             composable("plans"){
-                                PlansPage(navController, songDao, songScoreDao, artistDao)
+                                PlansPage(songDao, songScoreDao, artistDao, showDialog, editingSongScore)
                             }
                             composable("list"){
                                 ArtistsPage(navController, artistDao)

--- a/app/src/main/java/com/example/karaoke_note/MainActivity.kt
+++ b/app/src/main/java/com/example/karaoke_note/MainActivity.kt
@@ -57,7 +57,7 @@ class MainActivity : ComponentActivity() {
                             BottomNavigationBar(navController)
                         },
                         floatingActionButton = {
-                            NewEntryScreen(songDao, songScoreDao, artistDao, lifecycleScope, showDialog, editingSongScore, snackBarHostState)
+                            NewEntryScreen(navController, songDao, songScoreDao, artistDao, lifecycleScope, showDialog, editingSongScore, snackBarHostState)
                             //AnimatedContentFABtoDiagram()
                         },
                         snackbarHost = {

--- a/app/src/main/java/com/example/karaoke_note/MainActivity.kt
+++ b/app/src/main/java/com/example/karaoke_note/MainActivity.kt
@@ -57,7 +57,7 @@ class MainActivity : ComponentActivity() {
                             BottomNavigationBar(navController)
                         },
                         floatingActionButton = {
-                            NewEntryScreen(navController, songDao, songScoreDao, artistDao, lifecycleScope, showDialog, editingSongScore, snackBarHostState)
+                            NewEntryScreen(songDao, songScoreDao, artistDao, lifecycleScope, showDialog, editingSongScore, snackBarHostState)
                             //AnimatedContentFABtoDiagram()
                         },
                         snackbarHost = {

--- a/app/src/main/java/com/example/karaoke_note/NewEntrySheet.kt
+++ b/app/src/main/java/com/example/karaoke_note/NewEntrySheet.kt
@@ -77,9 +77,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.navigation.NavBackStackEntry
-import androidx.navigation.NavController
-import androidx.navigation.compose.currentBackStackEntryAsState
 import com.example.karaoke_note.data.Artist
 import com.example.karaoke_note.data.ArtistDao
 import com.example.karaoke_note.data.GameKind
@@ -513,31 +510,6 @@ fun getLocalizedDate(defaultDate: LocalDate): LocalDate {
     }
 
     return localizedSelectedDate
-}
-
-
-private fun getDefaultValuesBasedOnRoute(
-    backStackEntry: NavBackStackEntry?,
-    songDao: SongDao
-):Pair<Long, String> {
-    val currentRoute = backStackEntry?.destination?.route
-
-    return when {
-        currentRoute?.startsWith("song_data/") == true -> {
-            val songId = backStackEntry.arguments?.getString("songId")?.toLongOrNull()
-            val song = if (songId != null) songDao.getSong(songId) else null
-            Pair(song?.artistId ?: -1, song?.title ?: "")
-        }
-        currentRoute?.startsWith("song_list/") == true -> {
-            val artistId = backStackEntry.arguments?.getString("artistId")?.toLongOrNull()
-            if (artistId == null) {
-                Pair(-1, "")
-            } else {
-                Pair(artistId, "")
-            }
-        }
-        else -> Pair(-1, "")
-    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/example/karaoke_note/NewEntrySheet.kt
+++ b/app/src/main/java/com/example/karaoke_note/NewEntrySheet.kt
@@ -515,15 +515,12 @@ fun getLocalizedDate(defaultDate: LocalDate): LocalDate {
 @OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalMaterial3Api
 @Composable
-fun NewEntryScreen(navController: NavController, songDao: SongDao, songScoreDao: SongScoreDao, artistDao: ArtistDao, scope: CoroutineScope, screenOpened: MutableState<Boolean>, editingSongScoreState: MutableState<SongScore?>, snackBarHostState: SnackbarHostState) {
+fun NewEntryScreen(songDao: SongDao, songScoreDao: SongScoreDao, artistDao: ArtistDao, scope: CoroutineScope, screenOpened: MutableState<Boolean>, editingSongScoreState: MutableState<SongScore?>, snackBarHostState: SnackbarHostState) {
     val editingSongScore = editingSongScoreState.value
-    val currentBackStackEntry by navController.currentBackStackEntryAsState()
     var errorDialogOpened by remember { mutableStateOf(false) }
 
-    val (defaultArtistId, defaultTitle) = getDefaultValuesBasedOnRoute(
-        currentBackStackEntry,
-        songDao
-    )
+    val defaultArtistId = editingSongScore?.songId?.let { songDao.getSong(it)?.artistId } ?: -1
+    val defaultTitle = editingSongScore?.songId?.let { songDao.getSong(it)?.title } ?: ""
     val defaultScore = editingSongScore?.score?.let { String.format("%.3f", it) } ?: ""
     val defaultKey = editingSongScore?.key?.toFloat() ?: 0f
     val defaultDate = editingSongScore?.date ?: LocalDate.now()

--- a/app/src/main/java/com/example/karaoke_note/Plans.kt
+++ b/app/src/main/java/com/example/karaoke_note/Plans.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -24,16 +25,16 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
 import com.example.karaoke_note.data.ArtistDao
 import com.example.karaoke_note.data.Song
 import com.example.karaoke_note.data.SongDao
 import com.example.karaoke_note.data.SongScore
 import com.example.karaoke_note.data.SongScoreDao
+import java.time.LocalDate
 
 @ExperimentalMaterial3Api
 @Composable
-fun PlansPage(navController: NavController, songDao: SongDao, songScoreDao: SongScoreDao, artistDao: ArtistDao) {
+fun PlansPage(songDao: SongDao, songScoreDao: SongScoreDao, artistDao: ArtistDao, showEntrySheetDialog: MutableState<Boolean>, editingSongScore: MutableState<SongScore?>) {
     Column {
         Box(
             modifier = Modifier.weight(8f)
@@ -47,7 +48,7 @@ fun PlansPage(navController: NavController, songDao: SongDao, songScoreDao: Song
                     if (song != null) {
                         val artist = artistDao.getNameById(song.artistId)
                         if (artist != null) {
-                            PlansCard(song, songData, artist, navController)
+                            PlansCard(song, songData, artist, showEntrySheetDialog, editingSongScore)
                         }
                     } else {
                         // データベースが壊れている
@@ -60,7 +61,7 @@ fun PlansPage(navController: NavController, songDao: SongDao, songScoreDao: Song
 
 @ExperimentalMaterial3Api
 @Composable
-fun PlansCard(song: Song, songScore: SongScore, artist: String, navController: NavController) {
+fun PlansCard(song: Song, songScore: SongScore, artist: String, showEntrySheetDialog: MutableState<Boolean>, editingSongScore: MutableState<SongScore?>) {
     remember { mutableStateOf(false) }
     val keyFormat = if (songScore.key != 0) { "%+d" } else { "%d" }
 
@@ -69,7 +70,8 @@ fun PlansCard(song: Song, songScore: SongScore, artist: String, navController: N
     ) {
         Card(
             onClick = {
-                navController.navigate("song_data/${song.id}")
+                editingSongScore.value = songScore.copy(date = LocalDate.now())
+                showEntrySheetDialog.value = true
                       },
             shape = MaterialTheme.shapes.small,
             modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
#34 の一環。
アーティストと曲名を現在のページから取得していましたが、Plansページから遷移する場合はその情報がnavControllerからは取れないので素直にスコアから取得するようにします。
日付の取り方が怪しい(タイムゾーン関連で当日にならなかった問題がここにも影響するのかわかっていない)ので見てもらえると助かります。