### PR TITLE
アーティストアイコンの色を変えられるようにした

### DIFF
--- a/app/src/main/java/com/example/karaoke_note/ArtistsList.kt
+++ b/app/src/main/java/com/example/karaoke_note/ArtistsList.kt
@@ -179,7 +179,7 @@ fun ArtistsListDrawing(navController: NavController, artist: Artist, artistDao: 
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                for (index in 0..7) { // 7色
+                for (index in 0..7) { // 8色
                     IconButton(
                         onClick = {
                             onUpdate(artist.id, getARGB(index).toArgb())

--- a/app/src/main/java/com/example/karaoke_note/ArtistsList.kt
+++ b/app/src/main/java/com/example/karaoke_note/ArtistsList.kt
@@ -116,7 +116,6 @@ fun ArtistsListHeader(sortDirection: SortDirection, onSortChanged: (SortDirectio
 
 fun getARGB(colorNumber: Int): Color {
     var argb: Color = Color.Black
-
     when (colorNumber) {
         0 -> argb = Color.Black
         1 -> argb = Color.Red

--- a/app/src/main/java/com/example/karaoke_note/SongList.kt
+++ b/app/src/main/java/com/example/karaoke_note/SongList.kt
@@ -1,3 +1,4 @@
+
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,7 +13,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
@@ -25,11 +31,11 @@ import com.example.karaoke_note.data.ArtistDao
 import com.example.karaoke_note.data.Song
 import com.example.karaoke_note.data.SongDao
 import com.example.karaoke_note.data.SongScoreDao
-import java.time.LocalDate
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
+import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 data class SongData(val id: Long, val title: String, val highestScore: Float, val lastDate: LocalDate)
@@ -85,7 +91,6 @@ fun SongList(navController: NavController, artistId: Long, songDao: SongDao, son
 
     var text by remember { mutableStateOf(artistName) }
     var isEditing by remember { mutableStateOf(false) }
-
     Column {
         Row {
             if (isEditing) {

--- a/app/src/main/java/com/example/karaoke_note/SongScores.kt
+++ b/app/src/main/java/com/example/karaoke_note/SongScores.kt
@@ -118,7 +118,6 @@ fun SongScores(song: Song, songDao: SongDao, songScoreDao: SongScoreDao, scope: 
         )
     )
 
-
     var text by remember { mutableStateOf(song.title) }
     var isEditing by remember { mutableStateOf(false) }
     Column {

--- a/app/src/main/java/com/example/karaoke_note/data/Artist.kt
+++ b/app/src/main/java/com/example/karaoke_note/data/Artist.kt
@@ -1,7 +1,5 @@
 package com.example.karaoke_note.data
 
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
@@ -10,5 +8,5 @@ import androidx.room.PrimaryKey
 data class Artist (
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     @ColumnInfo(name = "name") val name: String,
-    @ColumnInfo(name = "icon_color") val iconColor: Int = Color.Black.toArgb(),
+    @ColumnInfo(name = "icon_color") var iconColor: Int,
 )

--- a/app/src/main/java/com/example/karaoke_note/data/ArtistDao.kt
+++ b/app/src/main/java/com/example/karaoke_note/data/ArtistDao.kt
@@ -35,6 +35,9 @@ interface ArtistDao {
     @Query("UPDATE Artist SET name = :name WHERE id = :id")
     fun updateName(id: Long, name: String)
 
+    @Query("UPDATE Artist SET icon_color = :iconColor WHERE id = :id")
+    fun updateIconColor(id: Long, iconColor: Int)
+
     @Query("DELETE FROM Artist")
     fun clearAllArtists()
 


### PR DESCRIPTION
アーティスト一覧ページにあるアイコンを長押しすると8色の選択肢が出てきます。
ちょっとマジックナンバー化してしまっているのが気になる・・・

ブランチ名が変ですが、元々アーティスト名を変えるところで Dialog を使って同時に変えられるようにしようと思っていたためです。