### PR TITLE
Plans データを編集した際の登録順序を自然にする

### DIFF
--- a/app/src/main/java/com/example/karaoke_note/MainActivity.kt
+++ b/app/src/main/java/com/example/karaoke_note/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.example.karaoke_note
 
-import SongList
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent

--- a/app/src/main/java/com/example/karaoke_note/Plans.kt
+++ b/app/src/main/java/com/example/karaoke_note/Plans.kt
@@ -16,9 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.*
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -36,9 +34,16 @@ import java.time.LocalDate
 
 @ExperimentalMaterial3Api
 @Composable
-fun PlansPage(songDao: SongDao, songScoreDao: SongScoreDao, artistDao: ArtistDao, showEntrySheetDialog: MutableState<Boolean>, editingSongScore: MutableState<SongScore?>) {
+fun PlansPage(
+    songDao: SongDao,
+    songScoreDao: SongScoreDao,
+    artistDao: ArtistDao,
+    showEntrySheetDialog: MutableState<Boolean>,
+    editingSongScore: MutableState<SongScore?>
+) {
     val songDataFlow = songScoreDao.getAll0Scores()
     val songDataList by songDataFlow.collectAsState(initial = listOf())
+
     Column {
         Box(
             modifier = Modifier.weight(8f)
@@ -64,8 +69,13 @@ fun PlansPage(songDao: SongDao, songScoreDao: SongScoreDao, artistDao: ArtistDao
 
 @ExperimentalMaterial3Api
 @Composable
-fun PlansCard(song: Song, songScore: SongScore, artist: String, showEntrySheetDialog: MutableState<Boolean>, editingSongScore: MutableState<SongScore?>) {
-    remember { mutableStateOf(false) }
+fun PlansCard(
+    song: Song,
+    songScore: SongScore,
+    artist: String,
+    showEntrySheetDialog: MutableState<Boolean>,
+    editingSongScore: MutableState<SongScore?>
+) {
     val keyFormat = if (songScore.key != 0) { "%+d" } else { "%d" }
 
     Column(

--- a/app/src/main/java/com/example/karaoke_note/SongList.kt
+++ b/app/src/main/java/com/example/karaoke_note/SongList.kt
@@ -1,4 +1,6 @@
-
+package com.example.karaoke_note
+import SortableTable
+import TableColumn
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -38,9 +40,17 @@ import kotlinx.coroutines.runBlocking
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-data class SongData(val id: Long, val title: String, val highestScore: Float, val lastDate: LocalDate)
+data class SongData(
+    val id: Long,
+    val title: String,
+    val highestScore: Float,
+    val lastDate: LocalDate
+)
 
-fun convertToSongDataList(songScoreDao: SongScoreDao, songs: List<Song>): List<SongData> {
+fun convertToSongDataList(
+    songScoreDao: SongScoreDao,
+    songs: List<Song>
+): List<SongData> {
     return runBlocking(Dispatchers.IO) {
         songs.map { song ->
             async {
@@ -57,7 +67,13 @@ fun convertToSongDataList(songScoreDao: SongScoreDao, songs: List<Song>): List<S
     }
 }
 @Composable
-fun SongList(navController: NavController, artistId: Long, songDao: SongDao, songScoreDao: SongScoreDao, artistDao: ArtistDao) {
+fun SongList(
+    navController: NavController,
+    artistId: Long,
+    songDao: SongDao,
+    songScoreDao: SongScoreDao,
+    artistDao: ArtistDao
+) {
     fun onUpdate(artistId: Long, newTitle: String) {
         artistDao.updateName(artistId, newTitle)
     }
@@ -72,18 +88,38 @@ fun SongList(navController: NavController, artistId: Long, songDao: SongDao, son
         TableColumn<SongData>("タイトル",
             {
                 val scrollState = rememberScrollState()
-                Text(text = it.title, modifier = Modifier.horizontalScroll(scrollState), fontSize = fontSize)
-            } ,
-            compareBy{ it.title },
+                Text(
+                    text = it.title,
+                    modifier = Modifier.horizontalScroll(scrollState),
+                    fontSize = fontSize
+                )
+            },
+            compareBy { it.title },
             2f
         ),
-        TableColumn<SongData>("最高スコア",
-            { Text(text = String.format("%.3f", it.highestScore), textAlign = TextAlign.End, modifier = Modifier.fillMaxWidth(), fontSize = fontSize) },
-            compareBy{ it.highestScore },
+        TableColumn<SongData>(
+            "最高スコア",
+            {
+                Text(
+                    text = String.format("%.3f", it.highestScore),
+                    textAlign = TextAlign.End,
+                    modifier = Modifier.fillMaxWidth(),
+                    fontSize = fontSize
+                )
+            },
+            compareBy { it.highestScore },
             2f
         ),
-        TableColumn<SongData>("最後に歌った日",
-            { Text(text = it.lastDate.format(formatter), textAlign = TextAlign.End, modifier = Modifier.fillMaxWidth(), fontSize = fontSize) },
+        TableColumn<SongData>(
+            "最後に歌った日",
+            {
+                Text(
+                    text = it.lastDate.format(formatter),
+                    textAlign = TextAlign.End,
+                    modifier = Modifier.fillMaxWidth(),
+                    fontSize = fontSize
+                )
+            },
             compareBy { it.lastDate },
             2f
         )


### PR DESCRIPTION
#121 に対する修正です。
Plans 仮登録データを編集して新規登録する際に SongScore.id = 0 として SongScore.id を自動で振りなおすよう修正しました。これで表示順序は自然になると思います。