### PR TITLE
新規登録画面を開いたときに前のデータが残っているバグを修正

### DIFF
--- a/app/src/main/java/com/example/karaoke_note/NewEntrySheet.kt
+++ b/app/src/main/java/com/example/karaoke_note/NewEntrySheet.kt
@@ -244,7 +244,8 @@ fun NewEntryScreen(
     var isSaveButtonEnabled by remember { mutableStateOf(false) }
     var isComeFromPlansPage = false
 
-    LaunchedEffect(key1 = defaultArtistId, key2 = defaultTitle, key3 = editingSongScore) {
+    //LaunchedEffect(key1 = defaultArtistId, key2 = defaultTitle, key3 = editingSongScore) {
+    LaunchedEffect(key1 = screenOpened.value) {
         isComeFromPlansPage = (defaultScore == "0.000")
 
         newArtist = artistDao.getNameById(defaultArtistId) ?: ""
@@ -302,6 +303,8 @@ fun NewEntryScreen(
                         IconButton(
                             onClick = {
                                 editingSongScoreState.value = null
+                                newTitle = ""    // default* で適切な値を取ってこられるのでクリアしてしまえ
+                                newArtist = ""
                                 newScore = ""
                                 newKey = 0f
                                 newDate = LocalDate.now()
@@ -345,6 +348,8 @@ fun NewEntryScreen(
                                 )
 
                                 editingSongScoreState.value = null
+                                newTitle = ""
+                                newArtist = ""
                                 newScore = ""
                                 newKey = 0f
                                 newDate = LocalDate.now()


### PR DESCRIPTION
#143 への対応です。
LaunchedEffect の開始きっかけ (key) が3つしか取れないので、思い切ってごっそり変えてみた。