### PR TITLE
Entry as plans スイッチを切った時の表示を修正

### DIFF
--- a/app/src/main/java/com/example/karaoke_note/NewEntrySheet.kt
+++ b/app/src/main/java/com/example/karaoke_note/NewEntrySheet.kt
@@ -245,7 +245,7 @@ fun NewEntryScreen(
     var isComeFromPlansPage = false
 
     //LaunchedEffect(key1 = defaultArtistId, key2 = defaultTitle, key3 = editingSongScore) {
-    LaunchedEffect(key1 = screenOpened.value) {
+    LaunchedEffect(key1 = screenOpened.value, key2 = isPlanning) {
         isComeFromPlansPage = (defaultScore == "0.000")
 
         newArtist = artistDao.getNameById(defaultArtistId) ?: ""


### PR DESCRIPTION
#150 への対応です。
Plans ページで新規登録画面を開き、Entry as plans スイッチを切った時に Supporting text の判定をきちんとするように修正しました。