### PR TITLE
疑似的な SegmentedButton

### DIFF
--- a/app/src/main/java/com/example/karaoke_note/ArtistsList.kt
+++ b/app/src/main/java/com/example/karaoke_note/ArtistsList.kt
@@ -7,10 +7,12 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -18,12 +20,15 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -40,6 +45,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.example.karaoke_note.data.Artist
 import com.example.karaoke_note.data.ArtistDao
@@ -52,14 +58,99 @@ fun ArtistsPage(
     artistDao: ArtistDao,
     songDao: SongDao
 ) {
+    var artistSelected by remember { mutableStateOf(true) }
+    val buttonWidth = 120
+    val buttonInnerPadding = 4
+    val buttonShape = 8
+    val buttonTextSize = 14
+
     Column {
-        Box(modifier = Modifier.weight(0.5f)) {
-            Spacer(modifier = Modifier)
+        // 疑似的な Segmented Button
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 8.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Row {
+                FilledTonalButton(
+                    onClick = { artistSelected = true },
+                    modifier = Modifier
+                        .width(buttonWidth.dp)
+                        .defaultMinSize(minHeight = 1.dp),
+                    contentPadding = PaddingValues(buttonInnerPadding.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = if (artistSelected) {
+                            MaterialTheme.colorScheme.secondaryContainer
+                        }
+                        else {
+                            MaterialTheme.colorScheme.surface
+                        },
+                        contentColor = if (artistSelected) {
+                            MaterialTheme.colorScheme.onSecondaryContainer
+                        }
+                        else {
+                            MaterialTheme.colorScheme.onSurface
+                        }
+                    ),
+                    shape = RoundedCornerShape(
+                        topStart = buttonShape.dp,
+                        bottomStart = buttonShape.dp,
+                        topEnd = 0.dp,
+                        bottomEnd = 0.dp
+                    )
+                ) {
+                    Text(
+                        text = "Artist",
+                        modifier = Modifier,
+                        fontSize = buttonTextSize.sp
+                    )
+                }
+                FilledTonalButton(
+                    onClick = { artistSelected = false },
+                    modifier = Modifier
+                        .width(buttonWidth.dp)
+                        .defaultMinSize(minHeight = 1.dp),
+                    contentPadding = PaddingValues(buttonInnerPadding.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = if (!artistSelected) {
+                            MaterialTheme.colorScheme.secondaryContainer
+                        }
+                        else {
+                            MaterialTheme.colorScheme.surface
+                        },
+                        contentColor = if (!artistSelected) {
+                            MaterialTheme.colorScheme.onSecondaryContainer
+                        }
+                        else {
+                            MaterialTheme.colorScheme.onSurface
+                        }
+                    ),
+                    shape = RoundedCornerShape(
+                        topStart = 0.dp,
+                        bottomStart = 0.dp,
+                        topEnd = buttonShape.dp,
+                        bottomEnd = buttonShape.dp,
+                    )
+                ) {
+                    Text(
+                        text = "All songs",
+                        modifier = Modifier,
+                        fontSize = buttonTextSize.sp
+                    )
+                }
+            }
         }
-        Box(modifier = Modifier.weight(9f)) {
-            val artistsFlow = artistDao.getArtistsWithSongs()
-            val artists by artistsFlow.collectAsState(initial = emptyList())
-            SortArtists(navController, artists, artistDao, songDao)
+
+        Box(modifier = Modifier) {
+            if (artistSelected) {
+                val artistsFlow = artistDao.getArtistsWithSongs()
+                val artists by artistsFlow.collectAsState(initial = emptyList())
+                SortArtists(navController, artists, artistDao, songDao)
+            }
+            else {
+                AllSongList()
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/karaoke_note/ArtistsList.kt
+++ b/app/src/main/java/com/example/karaoke_note/ArtistsList.kt
@@ -142,7 +142,7 @@ fun ArtistsPage(
             }
         }
 
-        Box(modifier = Modifier) {
+        Box(modifier = Modifier.fillMaxWidth()) {
             if (artistSelected) {
                 val artistsFlow = artistDao.getArtistsWithSongs()
                 val artists by artistsFlow.collectAsState(initial = emptyList())
@@ -272,11 +272,11 @@ fun ArtistsListDrawing(
     val songList by songsListFlow.collectAsState(initial = listOf())
     val numberOfSongs = songList.size
 
-    Column (
+    Column(
         modifier = Modifier.clickable {
             navController.navigate("song_list/${artist.id}")
         }
-    ){
+    ) {
         ListItem(
             headlineContent = {
                 Text(
@@ -299,7 +299,7 @@ fun ArtistsListDrawing(
                 )
             }
         )
-        Divider(color = Color.Gray, thickness = 1.dp)
+        Divider(thickness = 1.dp, color = Color.LightGray)
     }
 
     if (iconColorSelectorOpened) { // これもできれば切り出したいな

--- a/app/src/main/java/com/example/karaoke_note/ArtistsList.kt
+++ b/app/src/main/java/com/example/karaoke_note/ArtistsList.kt
@@ -101,7 +101,7 @@ fun ArtistsPage(
                     )
                 ) {
                     Text(
-                        text = "Artist",
+                        text = "Artists",
                         modifier = Modifier,
                         fontSize = buttonTextSize.sp
                     )
@@ -146,10 +146,10 @@ fun ArtistsPage(
             if (artistSelected) {
                 val artistsFlow = artistDao.getArtistsWithSongs()
                 val artists by artistsFlow.collectAsState(initial = emptyList())
-                SortArtists(navController, artists, artistDao, songDao)
+                DisplayArtistsList(navController, artists, artistDao, songDao)
             }
             else {
-                AllSongList()
+//                DisplayAllSongsList()
             }
         }
     }
@@ -157,7 +157,7 @@ fun ArtistsPage(
 
 @ExperimentalMaterial3Api
 @Composable
-fun SortArtists(
+fun DisplayArtistsList(
     navController: NavController,
     artists: List<Artist>,
     artistDao: ArtistDao,
@@ -176,7 +176,7 @@ fun SortArtists(
         ) {
             LazyColumn {
                 itemsIndexed(sortedArtists) { _, artist ->
-                    ArtistsListDrawing(navController, artist, artistDao, songDao)
+                    ArtistListItem(navController, artist, artistDao, songDao)
                 }
             }
         }
@@ -255,7 +255,7 @@ fun getARGB(colorNumber: Int): Color {
 @OptIn(ExperimentalFoundationApi::class)
 @ExperimentalMaterial3Api
 @Composable
-fun ArtistsListDrawing(
+fun ArtistListItem(
     navController: NavController,
     artist: Artist,
     artistDao: ArtistDao,

--- a/app/src/main/java/com/example/karaoke_note/Home.kt
+++ b/app/src/main/java/com/example/karaoke_note/Home.kt
@@ -4,29 +4,27 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowUpward
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -98,7 +96,7 @@ fun LatestPage(
                     if (song != null) {
                         val artist = artistDao.getNameById(song.artistId)
                         if (artist != null) {
-                            LatestCard(song, songScore, artist, navController)
+                            LatestList(song, songScore, artist, navController)
                         }
                     }
 
@@ -196,131 +194,105 @@ fun getPainterResourceIdOfGameImage(gameName: String): Int {
 
 @ExperimentalMaterial3Api
 @Composable
-fun LatestCard(
+fun LatestList(
     song: Song,
     songScore: SongScore,
     artist: String,
     navController: NavController
 ) {
-    var commentforcard = ""
-    if (songScore.comment.isNotEmpty()) {
-        commentforcard = "..."
-    }
     val keyFormat = if (songScore.key != 0) { "%+d" } else { "%d" }
 
-    Column(
-        modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp)
-    ) {
-        Card(
-            onClick = {
-                navController.navigate("song_data/${song.id}")
-            },
-            shape = MaterialTheme.shapes.medium,
-            modifier = Modifier.fillMaxWidth(),
-            colors = CardDefaults.cardColors(Color(0xffffffff)),
-            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
-        ) {
-            Row(
-                modifier = Modifier,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Box(
-                    modifier = Modifier.weight(3f),
-                ) {
-                    Column(
-                        modifier = Modifier,
-                        verticalArrangement = Arrangement.SpaceBetween
-                    ){
-                        Text(
-                            text = songScore.date.toString(),
-                            modifier = Modifier
-                                .padding(start = 16.dp, top = 8.dp, bottom = 8.dp)
-                                .align(Alignment.Start),
-                            color = Color.Gray,
-                            fontFamily = FontFamily.SansSerif,
-                            fontSize = 6.sp,
-                        )
-                        Text(
-                            text = song.title,
-                            modifier = Modifier
-                                .padding(start = 20.dp, top = 4.dp, bottom = 4.dp)
-                                .align(Alignment.Start),
-                            color = Color.DarkGray,
-                            fontFamily = FontFamily.SansSerif,
-                            fontSize = 12.sp,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                        Text(
-                            text = artist,
-                            modifier = Modifier
-                                .padding(start = 20.dp, top = 4.dp, bottom = 4.dp)
-                                .align(Alignment.Start),
-                            color = Color.Gray,
-                            fontFamily = FontFamily.SansSerif,
-                            fontSize = 8.sp,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                }
-                Box(
+    Column {
+        ListItem(
+            modifier = Modifier
+                .height(90.dp)
+                .clickable {
+                    navController.navigate("song_data/${song.id}")
+                },
+            leadingContent = {
+                Image(
+                    painter = painterResource(id = getPainterResourceIdOfGameImage(songScore.gameKind.name)),
+                    contentDescription = "Selected Game",
+                    contentScale = ContentScale.Fit,
                     modifier = Modifier
-                        .width(50.dp)
-                        .height(60.dp)
-                        .padding(top = 12.dp),
-                        //.background(Color.Blue),
-                ){
-                    Image(
-                        painter = painterResource(id = getPainterResourceIdOfGameImage(songScore.gameKind.name)),
-                        contentDescription = "Selected Game",
-                        contentScale = ContentScale.Fit,
+                        .size(30.dp)
+                )
+            },
+            headlineContent = {
+                Column {
+                    Text(
+                        text = songScore.date.toString(),
                         modifier = Modifier
-                            .size(30.dp)
-                            .align(Alignment.TopCenter)
+                            .padding(top = 2.dp, bottom = 6.dp)
+                            .align(Alignment.Start),
+                        color = Color.Gray,
+                        fontFamily = FontFamily.SansSerif,
+                        fontSize = 6.sp,
+                    )
+                    Text(
+                        text = song.title,
+                        modifier = Modifier
+                            .padding(top = 2.dp, bottom = 2.dp)
+                            .align(Alignment.Start),
+                        color = Color.DarkGray,
+                        fontFamily = FontFamily.SansSerif,
+                        fontSize = 12.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = artist,
+                        modifier = Modifier
+                            .padding(top = 2.dp, bottom = 6.dp)
+                            .align(Alignment.Start),
+                        color = Color.Gray,
+                        fontFamily = FontFamily.SansSerif,
+                        fontSize = 8.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                     )
                 }
-                Box(
+            },
+            supportingContent = {
+                Text(
+                    text = songScore.comment,
                     modifier = Modifier
-                        .width(80.dp)
-                        .height(80.dp)
-                        .padding(top = 6.dp),
-                        //.background(Color.Green),
-                    contentAlignment = Alignment.BottomEnd
-                ) {
-                    Column(
-                        verticalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Text(
-                            text = String.format("%.3f", songScore.score),
-                            modifier = Modifier
-                                .padding(top = 0.dp, end = 16.dp, bottom = 2.dp)
-                                .align(Alignment.End),
-                            color = Color.DarkGray,
-                            fontFamily = FontFamily.SansSerif,
-                            fontSize = 12.sp,
-                        )
-                        Text(
-                            text = String.format(keyFormat, songScore.key),
-                            modifier = Modifier
-                                .padding(top = 2.dp, end = 16.dp, bottom = 2.dp)
-                                .align(Alignment.End),
-                            color = Color.Red,
-                            fontFamily = FontFamily.SansSerif,
-                            fontSize = 10.sp,
-                        )
-                        Text(
-                            text = commentforcard,
-                            modifier = Modifier
-                                .padding(top = 2.dp, end = 16.dp, bottom = 8.dp)
-                                .align(Alignment.End),
-                            color = Color.DarkGray,
-                            fontFamily = FontFamily.SansSerif,
-                            fontSize = 10.sp,
-                        )
-                    }
+                        .padding(top = 2.dp, end = 4.dp, bottom = 2.dp),
+                    color = Color.DarkGray,
+                    fontFamily = FontFamily.SansSerif,
+                    fontSize = 8.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            },
+            trailingContent = {
+                Column {
+                    Text(
+                        text = String.format("%.3f", songScore.score),
+                        modifier = Modifier
+                            .padding(top = 0.dp, end = 16.dp, bottom = 2.dp)
+                            .align(Alignment.End),
+                        color = Color.DarkGray,
+                        fontFamily = FontFamily.SansSerif,
+                        fontSize = 12.sp,
+                    )
+                    Text(
+                        text = String.format(keyFormat, songScore.key),
+                        modifier = Modifier
+                            .padding(top = 2.dp, end = 16.dp, bottom = 2.dp)
+                            .align(Alignment.End),
+                        color = when (songScore.key) {
+                            0 -> Color.Black
+                            -7, -6, -5, -4, -3, -2, -1 -> Color.Red
+                            else -> Color.Blue
+                        },
+                        fontFamily = FontFamily.SansSerif,
+                        fontSize = 10.sp,
+                    )
                 }
-            }
-        }
+            },
+            shadowElevation = 1.dp
+        )
+        Divider(thickness = 1.dp, color = Color.LightGray)
     }
 }

--- a/app/src/main/java/com/example/karaoke_note/SongList.kt
+++ b/app/src/main/java/com/example/karaoke_note/SongList.kt
@@ -165,3 +165,10 @@ fun SongList(
         }
     }
 }
+
+
+@Composable
+fun AllSongList(
+
+) {
+}

--- a/app/src/main/java/com/example/karaoke_note/SongList.kt
+++ b/app/src/main/java/com/example/karaoke_note/SongList.kt
@@ -165,10 +165,3 @@ fun SongList(
         }
     }
 }
-
-
-@Composable
-fun AllSongList(
-
-) {
-}


### PR DESCRIPTION
全曲リストを表示する前準備（本当は全曲リストも実装したかったんだけど）
Jetpack Compose では Segmented Button が Planned なので、疑似的に通常 Button で作成。
アーティストを選択した後の表示（タイトル、ハイスコア、最後に歌った日）にアーティスト名も付けて表示したいところ。