### PR TITLE
検索バーからフォーカスを外す

### DIFF
--- a/app/src/main/java/com/example/karaoke_note/AppBar.kt
+++ b/app/src/main/java/com/example/karaoke_note/AppBar.kt
@@ -114,6 +114,7 @@ fun AppBar(
     TopAppBar(
         backgroundColor = MaterialTheme.colorScheme.surface,
         title = {},
+        elevation = 2.dp,
         navigationIcon = {
             if (canPop.value) {
                 IconButton(
@@ -266,8 +267,7 @@ fun FilterContents(
                 contentDescription = null,
                 modifier = Modifier
                     .padding(end = 8.dp)
-                    .scale(0.75f)
-                ,
+                    .scale(0.75f),
                 tint = MaterialTheme.colorScheme.primary,
             )
             Text(text = "Game", fontWeight = FontWeight.Bold)
@@ -292,7 +292,6 @@ fun FilterContentGroup(
     gameSelected: Map<GameKind, MutableState<Boolean>>,
     modifier: Modifier = Modifier
 ) {
-
     Column (
         modifier = modifier
     ) {

--- a/app/src/main/java/com/example/karaoke_note/AppBar.kt
+++ b/app/src/main/java/com/example/karaoke_note/AppBar.kt
@@ -45,7 +45,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -75,6 +74,7 @@ import com.example.karaoke_note.data.Song
 import com.example.karaoke_note.data.SongDao
 import com.example.karaoke_note.data.SongScore
 import com.example.karaoke_note.data.SongScoreDao
+import com.example.karaoke_note.ui.component.CustomTextField
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonDeserializer
@@ -131,7 +131,7 @@ fun AppBar(
                 modifier = Modifier.align(alignment = Alignment.CenterVertically)
             ) {
                 // 検索ウインドウ
-                TextField(
+                CustomTextField(
                     value = searchText.value,
                     onValueChange = { searchText.value = it },
                     placeholder = { Text(text = "検索") },
@@ -149,7 +149,10 @@ fun AppBar(
                     trailingIcon = {
                         // バツボタン（クリアボタン）
                         if (searchText.value.isNotEmpty()) {
-                            IconButton(onClick = { searchText.value = "" }) {
+                            IconButton(
+                                onClick = { searchText.value = "" },
+                                modifier = Modifier.scale(0.8f)
+                            ){
                                 Icon(
                                     imageVector = Icons.Filled.Close,
                                     contentDescription = "Clear text"
@@ -175,7 +178,8 @@ fun AppBar(
                         focusedIndicatorColor = Color.Transparent,
                         unfocusedIndicatorColor = Color.Transparent,
                         disabledIndicatorColor = Color.Transparent
-                    )
+                    ),
+                    contentPadding = TextFieldDefaults.contentPaddingWithoutLabel(0.dp, 0.dp, 0.dp, 0.dp)
                 )
 
                 // フィルターボタン

--- a/app/src/main/java/com/example/karaoke_note/AppBar.kt
+++ b/app/src/main/java/com/example/karaoke_note/AppBar.kt
@@ -98,7 +98,7 @@ fun AppBar(
     filterSetting: MutableState<FilterSetting>,
     searchText: MutableState<String>,
     focusRequesterForSearchBar: FocusRequester,
-    focusManagerForSearchBar: FocusManager
+    focusManagerOfSearchBar: FocusManager
 ) {
     val canPop = remember { mutableStateOf(false) }
     val showMenu = remember { mutableStateOf(false) }
@@ -118,8 +118,8 @@ fun AppBar(
             if (canPop.value) {
                 IconButton(
                     onClick = {
+                        clearFocusFromSearchBar(focusManagerOfSearchBar)
                         navController.navigateUp()
-                        focusManagerForSearchBar.clearFocus()
                     }
                 ) {
                     Icon(Icons.Filled.ArrowBack, contentDescription = null)
@@ -160,8 +160,8 @@ fun AppBar(
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
                     keyboardActions = KeyboardActions(
                         onSearch = {
-                            // onSearch 状態になると TextField へのフォーカスをクリアする
-                            focusManagerForSearchBar.clearFocus()
+                            // Search キーを押すと TextField からフォーカスを外す
+                            clearFocusFromSearchBar(focusManagerOfSearchBar)
                         }
                     ),
                     shape = RoundedCornerShape(50),
@@ -181,8 +181,8 @@ fun AppBar(
                 // フィルターボタン
                 IconButton(
                     onClick = {
+                        clearFocusFromSearchBar(focusManagerOfSearchBar)
                         showSheet = true
-                        focusManagerForSearchBar.clearFocus()
                     }
                 ) {
                     Icon(
@@ -199,8 +199,8 @@ fun AppBar(
                 // メニューボタン
                 IconButton(
                     onClick = {
+                        clearFocusFromSearchBar(focusManagerOfSearchBar)
                         showMenu.value = true
-                        focusManagerForSearchBar.clearFocus()
                     }
                 ) {
                     Icon(

--- a/app/src/main/java/com/example/karaoke_note/AppBar.kt
+++ b/app/src/main/java/com/example/karaoke_note/AppBar.kt
@@ -19,6 +19,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -56,10 +58,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.example.karaoke_note.data.Artist
 import com.example.karaoke_note.data.ArtistDao
@@ -91,7 +96,9 @@ fun AppBar(
     songScoreDao: SongScoreDao,
     artistDao: ArtistDao,
     filterSetting: MutableState<FilterSetting>,
-    searchText: MutableState<String>
+    searchText: MutableState<String>,
+    focusRequesterForSearchBar: FocusRequester,
+    focusManagerForSearchBar: FocusManager
 ) {
     val canPop = remember { mutableStateOf(false) }
     val showMenu = remember { mutableStateOf(false) }
@@ -105,17 +112,15 @@ fun AppBar(
     }
 
     TopAppBar(
-        backgroundColor = MaterialTheme.colorScheme.primaryContainer,
-        title = {
-            Text(
-                text = "カラオケ点数管理",
-                fontSize = 16.sp
-            )
-        },
+        backgroundColor = MaterialTheme.colorScheme.surface,
+        title = {},
         navigationIcon = {
             if (canPop.value) {
                 IconButton(
-                    onClick = { navController.navigateUp() }
+                    onClick = {
+                        navController.navigateUp()
+                        focusManagerForSearchBar.clearFocus()
+                    }
                 ) {
                     Icon(Icons.Filled.ArrowBack, contentDescription = null)
                 }
@@ -132,7 +137,8 @@ fun AppBar(
                     placeholder = { Text(text = "検索") },
                     modifier = Modifier
                         .weight(1f)
-                        .padding(end = 8.dp),
+                        .padding(end = 8.dp)
+                        .focusRequester(focusRequesterForSearchBar),
                     singleLine = true,
                     leadingIcon = {
                         Icon(
@@ -151,11 +157,21 @@ fun AppBar(
                             }
                         }
                     },
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                    keyboardActions = KeyboardActions(
+                        onSearch = {
+                            // onSearch 状態になると TextField へのフォーカスをクリアする
+                            focusManagerForSearchBar.clearFocus()
+                        }
+                    ),
                     shape = RoundedCornerShape(50),
                     colors = TextFieldDefaults.colors(
-                        focusedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
-                        unfocusedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
-                        disabledContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        focusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        unfocusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        disabledTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
                         focusedIndicatorColor = Color.Transparent,
                         unfocusedIndicatorColor = Color.Transparent,
                         disabledIndicatorColor = Color.Transparent
@@ -164,7 +180,10 @@ fun AppBar(
 
                 // フィルターボタン
                 IconButton(
-                    onClick = { showSheet = true }
+                    onClick = {
+                        showSheet = true
+                        focusManagerForSearchBar.clearFocus()
+                    }
                 ) {
                     Icon(
                         imageVector = if (filterSetting.value.isDefault()) {
@@ -179,7 +198,10 @@ fun AppBar(
 
                 // メニューボタン
                 IconButton(
-                    onClick = { showMenu.value = true }
+                    onClick = {
+                        showMenu.value = true
+                        focusManagerForSearchBar.clearFocus()
+                    }
                 ) {
                     Icon(
                         imageVector = Icons.Filled.MoreVert,

--- a/app/src/main/java/com/example/karaoke_note/AppBar.kt
+++ b/app/src/main/java/com/example/karaoke_note/AppBar.kt
@@ -241,6 +241,10 @@ fun AppBar(
     }
 }
 
+fun clearFocusFromSearchBar(focusManager: FocusManager) {
+    focusManager.clearFocus()
+}
+
 @Composable
 fun FilterContents(
     filterSetting: MutableState<FilterSetting>

--- a/app/src/main/java/com/example/karaoke_note/Breadcrumbs.kt
+++ b/app/src/main/java/com/example/karaoke_note/Breadcrumbs.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
@@ -30,6 +31,7 @@ fun truncateText(
 @Composable
 fun Breadcrumbs(
     navController: NavController,
+    focusManagerOfSearchBar: FocusManager,
     songDao: SongDao,
     artistDao: ArtistDao
 ) {
@@ -79,7 +81,11 @@ fun Breadcrumbs(
             //Text(" > ")
             Text(
                 truncateText(artistName!!, 8),
-                modifier = Modifier.clickable { navController.navigate("song_list/$artistId") },
+                modifier = Modifier
+                    .clickable {
+                        focusManagerOfSearchBar.clearFocus()
+                        navController.navigate("song_list/$artistId")
+                    },
                 fontSize = fontSize.sp
             )
         }

--- a/app/src/main/java/com/example/karaoke_note/Latest.kt
+++ b/app/src/main/java/com/example/karaoke_note/Latest.kt
@@ -33,10 +33,12 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.*
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -62,6 +64,7 @@ fun LatestPage(
     artistDao: ArtistDao,
     filterSetting: FilterSetting,
     searchText: String,
+    focusManagerForSearchBar: FocusManager
 ) {
     val coroutineScope = rememberCoroutineScope()
     val listState = rememberLazyListState()
@@ -119,7 +122,7 @@ fun LatestPage(
                     if (song != null) {
                         val artist = artistDao.getNameById(song.artistId)
                         if (artist != null) {
-                            LatestList(song, songScore, artist, navController)
+                            LatestList(song, songScore, artist, focusManagerForSearchBar, navController)
                         }
                     }
                 }
@@ -142,6 +145,7 @@ fun LatestPage(
             AnimatedScrollUpButton(
                 isVisible = (!isTopOfList),
             ){
+                focusManagerForSearchBar.clearFocus()
                 coroutineScope.launch {
                     listState.animateScrollToItem(index = 0)
                 }
@@ -216,6 +220,7 @@ fun LatestList(
     song: Song,
     songScore: SongScore,
     artist: String,
+    focusManagerForSearchBar: FocusManager,
     navController: NavController
 ) {
     val keyFormat = if (songScore.key != 0) { "%+d" } else { "%d" }
@@ -225,7 +230,10 @@ fun LatestList(
         ListItem(
             modifier = Modifier
                 //.height(90.dp)
-                .clickable { navController.navigate("song_data/${song.id}") },
+                .clickable {
+                    focusManagerForSearchBar.clearFocus()
+                    navController.navigate("song_data/${song.id}")
+                },
             leadingContent = {
                 Image(
                     painter = painterResource(id = getPainterResourceIdOfGameImage(songScore.gameKind.name)),

--- a/app/src/main/java/com/example/karaoke_note/Latest.kt
+++ b/app/src/main/java/com/example/karaoke_note/Latest.kt
@@ -64,7 +64,7 @@ fun LatestPage(
     artistDao: ArtistDao,
     filterSetting: FilterSetting,
     searchText: String,
-    focusManagerForSearchBar: FocusManager
+    focusManagerOfSearchBar: FocusManager
 ) {
     val coroutineScope = rememberCoroutineScope()
     val listState = rememberLazyListState()
@@ -122,7 +122,7 @@ fun LatestPage(
                     if (song != null) {
                         val artist = artistDao.getNameById(song.artistId)
                         if (artist != null) {
-                            LatestList(song, songScore, artist, focusManagerForSearchBar, navController)
+                            LatestList(song, songScore, artist, focusManagerOfSearchBar, navController)
                         }
                     }
                 }
@@ -145,7 +145,7 @@ fun LatestPage(
             AnimatedScrollUpButton(
                 isVisible = (!isTopOfList),
             ){
-                focusManagerForSearchBar.clearFocus()
+                clearFocusFromSearchBar(focusManagerOfSearchBar)
                 coroutineScope.launch {
                     listState.animateScrollToItem(index = 0)
                 }
@@ -220,7 +220,7 @@ fun LatestList(
     song: Song,
     songScore: SongScore,
     artist: String,
-    focusManagerForSearchBar: FocusManager,
+    focusManagerOfSearchBar: FocusManager,
     navController: NavController
 ) {
     val keyFormat = if (songScore.key != 0) { "%+d" } else { "%d" }
@@ -231,7 +231,7 @@ fun LatestList(
             modifier = Modifier
                 //.height(90.dp)
                 .clickable {
-                    focusManagerForSearchBar.clearFocus()
+                    focusManagerOfSearchBar.clearFocus()
                     navController.navigate("song_data/${song.id}")
                 },
             leadingContent = {

--- a/app/src/main/java/com/example/karaoke_note/MainActivity.kt
+++ b/app/src/main/java/com/example/karaoke_note/MainActivity.kt
@@ -17,6 +17,8 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -38,6 +40,7 @@ class MainActivity : ComponentActivity() {
         val artistDao = AppDatabase.getDatabase(this).artistDao()
         setContent {
             Karaoke_noteTheme {
+                // Snackbar の状態
                 val snackBarHostState = remember { SnackbarHostState() }
                 // NewEntrySheet を開いているかどうか
                 val showDialog = remember { mutableStateOf(false) }
@@ -50,6 +53,9 @@ class MainActivity : ComponentActivity() {
                 val filterSetting = remember { mutableStateOf(FilterSetting()) }
                 // 検索文字列の設定
                 val searchText = remember { mutableStateOf("") }
+                // Search bar に対するフォーカスの変更を管理する
+                val focusRequesterForSearchBar = remember { FocusRequester() }
+                val focusManagerForSearchBar = LocalFocusManager.current
 
                 // A surface container using the 'background' color from the theme
                 Surface(
@@ -60,7 +66,7 @@ class MainActivity : ComponentActivity() {
                     Scaffold(
                         topBar = {
                             Column {
-                                AppBar(navController, songDao, songScoreDao, artistDao, filterSetting, searchText)
+                                AppBar(navController, songDao, songScoreDao, artistDao, filterSetting, searchText, focusRequesterForSearchBar, focusManagerForSearchBar)
                                 Breadcrumbs(navController, songDao, artistDao)
                             }
                         },
@@ -80,7 +86,7 @@ class MainActivity : ComponentActivity() {
                             Modifier.padding(paddingValues)
                         ) {
                             composable("latest") {
-                                LatestPage(navController, songDao, songScoreDao, artistDao, filterSetting.value, searchText.value)
+                                LatestPage(navController, songDao, songScoreDao, artistDao, filterSetting.value, searchText.value, focusManagerForSearchBar)
                             }
                             composable("song_data/{songId}") {backStackEntry ->
                                 val songId = backStackEntry.arguments?.getString("songId")?.toLongOrNull()

--- a/app/src/main/java/com/example/karaoke_note/MainActivity.kt
+++ b/app/src/main/java/com/example/karaoke_note/MainActivity.kt
@@ -53,9 +53,9 @@ class MainActivity : ComponentActivity() {
                 val filterSetting = remember { mutableStateOf(FilterSetting()) }
                 // 検索文字列の設定
                 val searchText = remember { mutableStateOf("") }
-                // Search bar に対するフォーカスの変更を管理する
+                // SearchBar に対するフォーカスの変更を管理する
                 val focusRequesterForSearchBar = remember { FocusRequester() }
-                val focusManagerForSearchBar = LocalFocusManager.current
+                val focusManagerOfSearchBar = LocalFocusManager.current
 
                 // A surface container using the 'background' color from the theme
                 Surface(
@@ -66,15 +66,15 @@ class MainActivity : ComponentActivity() {
                     Scaffold(
                         topBar = {
                             Column {
-                                AppBar(navController, songDao, songScoreDao, artistDao, filterSetting, searchText, focusRequesterForSearchBar, focusManagerForSearchBar)
-                                Breadcrumbs(navController, songDao, artistDao)
+                                AppBar(navController, songDao, songScoreDao, artistDao, filterSetting, searchText, focusRequesterForSearchBar, focusManagerOfSearchBar)
+                                Breadcrumbs(navController, focusManagerOfSearchBar, songDao, artistDao)
                             }
                         },
                         bottomBar = {
                             BottomNavigationBar(navController, songScoreDao)
                         },
                         floatingActionButton = {
-                            NewEntryScreen(navController, songDao, songScoreDao, artistDao, lifecycleScope, showDialog, editingSongScore, snackBarHostState)
+                            NewEntryScreen(navController, songDao, songScoreDao, artistDao, lifecycleScope, showDialog, editingSongScore, snackBarHostState, focusManagerOfSearchBar)
                         },
                         snackbarHost = {
                             SnackbarHost(snackBarHostState)
@@ -86,14 +86,14 @@ class MainActivity : ComponentActivity() {
                             Modifier.padding(paddingValues)
                         ) {
                             composable("latest") {
-                                LatestPage(navController, songDao, songScoreDao, artistDao, filterSetting.value, searchText.value, focusManagerForSearchBar)
+                                LatestPage(navController, songDao, songScoreDao, artistDao, filterSetting.value, searchText.value, focusManagerOfSearchBar)
                             }
                             composable("song_data/{songId}") {backStackEntry ->
                                 val songId = backStackEntry.arguments?.getString("songId")?.toLongOrNull()
                                 if (songId != null) {
                                     val song = songDao.getSong(songId)
                                     if (song != null) {
-                                        SongScores(song, songDao, songScoreDao, lifecycleScope, showDialog, editingSongScore, filterSetting.value, searchText.value)
+                                        SongScores(song, songDao, songScoreDao, lifecycleScope, showDialog, editingSongScore, filterSetting.value, searchText.value, focusManagerOfSearchBar)
                                     }
                                 }
                             }
@@ -101,12 +101,12 @@ class MainActivity : ComponentActivity() {
                                 PlansPage(songDao, songScoreDao, artistDao, showDialog, editingSongScore, lifecycleScope, snackBarHostState)
                             }
                             composable("list"){
-                                ArtistsPage(navController, isArtistListSelected, sortMethodOfAllSongs, artistDao, songDao, songScoreDao, filterSetting.value, searchText.value)
+                                ArtistsPage(navController, isArtistListSelected, sortMethodOfAllSongs, artistDao, songDao, songScoreDao, filterSetting.value, searchText.value, focusManagerOfSearchBar)
                             }
                             composable("song_list/{artistId}"){backStackEntry ->
                                 val artistId = backStackEntry.arguments?.getString("artistId")?.toLongOrNull()
                                 if (artistId != null) {
-                                    SongList(navController, artistId, songDao, songScoreDao, artistDao, filterSetting.value, searchText.value)
+                                    SongList(navController, artistId, songDao, songScoreDao, artistDao, filterSetting.value, searchText.value, focusManagerOfSearchBar)
                                 }
                             }
                         }

--- a/app/src/main/java/com/example/karaoke_note/NewEntrySheet.kt
+++ b/app/src/main/java/com/example/karaoke_note/NewEntrySheet.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.ImeAction
@@ -199,7 +200,8 @@ fun NewEntryScreen(
     scope: CoroutineScope,
     screenOpened: MutableState<Boolean>,
     editingSongScoreState: MutableState<SongScore?>,
-    snackBarHostState: SnackbarHostState
+    snackBarHostState: SnackbarHostState,
+    focusManagerOfSearchBar: FocusManager
 ) {
     val editingSongScore = editingSongScoreState.value
     val currentBackStackEntry by navController.currentBackStackEntryAsState()
@@ -247,6 +249,9 @@ fun NewEntryScreen(
 
     //LaunchedEffect(key1 = defaultArtistId, key2 = defaultTitle, key3 = editingSongScore) {
     LaunchedEffect(key1 = screenOpened.value, key2 = isPlanning) {
+        // ここに書けばすべて賄える
+        clearFocusFromSearchBar(focusManagerOfSearchBar)
+
         isComeFromPlansPage = (defaultScore == "0.000")
 
         newArtist = artistDao.getNameById(defaultArtistId) ?: ""

--- a/app/src/main/java/com/example/karaoke_note/SongList.kt
+++ b/app/src/main/java/com/example/karaoke_note/SongList.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
@@ -84,7 +85,8 @@ fun SongList(
     songScoreDao: SongScoreDao,
     artistDao: ArtistDao,
     filterSetting: FilterSetting,
-    searchText: String
+    searchText: String,
+    focusManagerOfSearchBar: FocusManager
 ) {
     fun onUpdate(artistId: Long, newTitle: String) {
         artistDao.updateName(artistId, newTitle)
@@ -189,8 +191,14 @@ fun SongList(
             color = MaterialTheme.colorScheme.outlineVariant,
             thickness = 1.dp
         )
-        SortableTable(items = songDatum, columns = columns) { item ->
-            navController.navigate("song_data/${item.id}")
-        }
+        SortableTable(
+            items = songDatum,
+            columns = columns,
+            onHeaderClick = { clearFocusFromSearchBar(focusManagerOfSearchBar) },
+            onRowClick = { item ->
+                clearFocusFromSearchBar(focusManagerOfSearchBar)
+                navController.navigate("song_data/${item.id}")
+            }
+        )
     }
 }

--- a/app/src/main/java/com/example/karaoke_note/SongScores.kt
+++ b/app/src/main/java/com/example/karaoke_note/SongScores.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
@@ -57,7 +58,8 @@ fun SongScores(
     showEntrySheetDialog: MutableState<Boolean>,
     editingSongScore: MutableState<SongScore?>,
     filterSetting: FilterSetting,
-    searchText: String
+    searchText: String,
+    focusManagerOfSearchBar: FocusManager
 ) {
     fun onUpdate(songId: Long, newTitle: String) {
         scope.launch {
@@ -137,6 +139,7 @@ fun SongScores(
                 val expanded = remember { mutableStateOf(false) }
                 IconButton(
                     onClick = {
+                        clearFocusFromSearchBar(focusManagerOfSearchBar)
                         expanded.value = true
                         selectedScoreId.value = songScore.id
                     },
@@ -211,7 +214,10 @@ fun SongScores(
                 )
             }
             IconButton(
-                onClick = { isEditing = true }
+                onClick = {
+                    clearFocusFromSearchBar(focusManagerOfSearchBar)
+                    isEditing = true
+                }
             ) {
                 // 通常状態だと位置が下にずれて見えるが、編集状態だとぴったり真ん中になる
                 Icon(
@@ -225,10 +231,18 @@ fun SongScores(
             color = MaterialTheme.colorScheme.outlineVariant,
             thickness = 1.dp
         )
-        SortableTable(items = filteredScores, columns = columns) {
-            openDetailDialog = true
-            selectedScore.value = it
-        }
+        SortableTable(
+            items = filteredScores,
+            columns = columns,
+            onHeaderClick = {
+                clearFocusFromSearchBar(focusManagerOfSearchBar)
+            },
+            onRowClick = {
+                clearFocusFromSearchBar(focusManagerOfSearchBar)
+                openDetailDialog = true
+                selectedScore.value = it
+            }
+        )
     }
     
     if (openDetailDialog) {

--- a/app/src/main/java/com/example/karaoke_note/SortableTable.kt
+++ b/app/src/main/java/com/example/karaoke_note/SortableTable.kt
@@ -40,6 +40,7 @@ fun <T> SortableTable(
     items: List<T>,
     columns: List<TableColumn<T>>,
     initialSortColumnIndex: Int = 0,
+    onHeaderClick: () -> Unit = {},
     onRowClick: (T) -> Unit = {}
 ) {
     var sortDirection by remember { mutableStateOf(SortDirection.None) }
@@ -61,6 +62,7 @@ fun <T> SortableTable(
         HeaderRow(columns, sortColumnIndex, sortDirection) { newSortColumnIndex, newSortDirection ->
             sortColumnIndex = newSortColumnIndex
             sortDirection = newSortDirection
+            onHeaderClick()
         }
         Divider(
             color = MaterialTheme.colorScheme.outlineVariant,

--- a/app/src/main/java/com/example/karaoke_note/ui/component/CustomTextField.kt
+++ b/app/src/main/java/com/example/karaoke_note/ui/component/CustomTextField.kt
@@ -1,0 +1,83 @@
+package com.example.karaoke_note.ui.component
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CustomTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = LocalTextStyle.current,
+    label: @Composable() (() -> Unit)? = null,
+    placeholder: @Composable() (() -> Unit)? = null,
+    leadingIcon: @Composable() (() -> Unit)? = null,
+    trailingIcon: @Composable() (() -> Unit)? = null,
+    prefix: @Composable() (() -> Unit)? = null,
+    suffix: @Composable() (() -> Unit)? = null,
+    supportingText: @Composable() (() -> Unit)? = null,
+    isError: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int. MAX_VALUE,
+    minLines: Int = 1,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    shape: Shape = TextFieldDefaults.shape,
+    colors: TextFieldColors = TextFieldDefaults.colors(),
+    contentPadding: PaddingValues = TextFieldDefaults.contentPaddingWithoutLabel(0.dp, 0.dp, 0.dp, 0.dp)
+){
+    BasicTextField(
+        value = value,
+        onValueChange = { onValueChange(it) },
+        modifier = modifier.fillMaxWidth(),
+        enabled = enabled,
+        readOnly = readOnly,
+        textStyle = textStyle,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        interactionSource = interactionSource,
+        singleLine = singleLine,
+        maxLines = maxLines,
+        minLines = minLines
+    ) { innerTextField ->
+        TextFieldDefaults.DecorationBox(
+            value = value,
+            innerTextField = innerTextField,
+            enabled = enabled,
+            singleLine = singleLine,
+            visualTransformation = visualTransformation,
+            interactionSource = interactionSource,
+            label = label,
+            placeholder = placeholder,
+            leadingIcon = leadingIcon,
+            trailingIcon = trailingIcon,
+            prefix = prefix,
+            suffix = suffix,
+            supportingText = supportingText,
+            isError = isError,
+            shape = shape,
+            colors = colors,
+            contentPadding = contentPadding
+        )
+    }
+}


### PR DESCRIPTION
以下の場合に検索バーからフォーカスを外すようにしました。
・キーボードで検索結果を確定したとき
・いろんなボタンを押したとき
　（BottomAppBar の3ボタンは除く）
　（確認したつもりだが設定し忘れがあったらごめんなさい）

また、TopAppBar を primaryContainer カラーにしていましたが surface カラーに変えました。
（特にダークテーマにすると）primaryContainer カラーは比較的濃い色であり、その上に検索バーを置くと色合いが非常に悪い。妙に目立つか溶け込み過ぎてわからなくなるのどちらかになってしまうので primaryContainer カラー自体を止めました。

以下についてはやり方を模索しましたが実現できませんでした。
・キーボード左下の隠すボタン (v) を押したときにフォーカスを外すこと
　（隠すボタンを押した判定をどうやって取得するのかがわからず・・・）
・検索結果をタップしたあとに検索結果をクリアすること
　（曲名などでヒットした Card をタップすると (多くの場合は) 結果リストで何も表示されない。直近の検索結果が生きており、結果ページではコメントで検索する仕様になっているため）
・検索バーの縦幅をもっと狭くすること
　（CustomTextField コンポーズを作ってある程度は狭くできたんですが、0.dp にしている割には広い）