### PR TITLE
Warning 除去

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,23 +52,25 @@ dependencies {
 
     implementation 'androidx.core:core-ktx:1.16.0'
     implementation platform('org.jetbrains.kotlin:kotlin-bom:2.1.20')
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.8.7'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.9.0'
     implementation 'androidx.activity:activity-compose:1.10.1'
-    implementation platform('androidx.compose:compose-bom:2025.04.01')
+    implementation platform('androidx.compose:compose-bom:2025.05.00')
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3:1.3.2'
-    implementation 'androidx.compose.material:material:1.8.0'
+    implementation 'androidx.compose.material:material:1.8.1'
     implementation 'androidx.compose.material:material-icons-extended:1.7.8'
 
-    def nav_version = '2.8.9'
+    def nav_version = '2.9.0'
+    //noinspection GradleDependency
     implementation "androidx.navigation:navigation-compose:$nav_version"
 
-    def room_version = "2.7.0"
+    def room_version = "2.7.1"
     implementation "androidx.room:room-runtime:$room_version"
     annotationProcessor "androidx.room:room-compiler:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
+    //noinspection GradleDependency
     implementation "androidx.room:room-ktx:$room_version"
     implementation 'com.google.code.gson:gson:2.13.0'
 
@@ -76,7 +78,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
-    androidTestImplementation platform('androidx.compose:compose-bom:2025.04.01')
+    androidTestImplementation platform('androidx.compose:compose-bom:2025.05.00')
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
-    id 'kotlin-kapt'
+    id 'com.google.devtools.ksp'
     id 'org.jetbrains.kotlin.plugin.compose'
 }
 
@@ -63,14 +63,12 @@ dependencies {
     implementation 'androidx.compose.material:material-icons-extended:1.7.8'
 
     def nav_version = '2.9.0'
-    //noinspection GradleDependency
     implementation "androidx.navigation:navigation-compose:$nav_version"
 
     def room_version = "2.7.1"
     implementation "androidx.room:room-runtime:$room_version"
     annotationProcessor "androidx.room:room-compiler:$room_version"
-    kapt "androidx.room:room-compiler:$room_version"
-    //noinspection GradleDependency
+    ksp "androidx.room:room-compiler:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
     implementation 'com.google.code.gson:gson:2.13.0'
 

--- a/app/src/main/java/com/example/karaoke_note/AllSongList.kt
+++ b/app/src/main/java/com/example/karaoke_note/AllSongList.kt
@@ -9,9 +9,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -237,6 +237,6 @@ fun AllSongsListItem(
             },
             shadowElevation = 1.dp
         )
-        Divider(thickness = 1.dp, color = MaterialTheme.colorScheme.outlineVariant)
+        HorizontalDivider(thickness = 1.dp, color = MaterialTheme.colorScheme.outlineVariant)
     }
 }

--- a/app/src/main/java/com/example/karaoke_note/AppBar.kt
+++ b/app/src/main/java/com/example/karaoke_note/AppBar.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
@@ -46,6 +45,8 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -112,9 +113,7 @@ fun AppBar(
     }
 
     TopAppBar(
-        backgroundColor = MaterialTheme.colorScheme.surface,
         title = {},
-        elevation = 2.dp,
         navigationIcon = {
             if (canPop.value) {
                 IconButton(
@@ -230,7 +229,9 @@ fun AppBar(
                     }
                 }
             }
-        }
+        },
+        colors = TopAppBarDefaults.topAppBarColors(),
+        scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
     )
 
     if (showSheet) {

--- a/app/src/main/java/com/example/karaoke_note/AppBar.kt
+++ b/app/src/main/java/com/example/karaoke_note/AppBar.kt
@@ -301,7 +301,7 @@ fun FilterContentGroup(
     selectedStatus: MutableState<Boolean>,
     gameSelected: Map<GameKind, MutableState<Boolean>>,
 ) {
-    Column() {
+    Column {
         // 採点ゲームグループ
         FilterContent(
             label = label,
@@ -323,7 +323,7 @@ fun FilterContentGroup(
                     .padding(start = 2.dp, end = 2.dp)
                     .horizontalScroll(rememberScrollState())
             ) {
-                gameSelected.entries.forEach() { entry ->
+                gameSelected.entries.forEach { entry ->
                     FilterContent(
                         label = entry.key.displayName,
                         modifier = Modifier.padding(horizontal = 5.dp, vertical = 4.dp),

--- a/app/src/main/java/com/example/karaoke_note/AppBar.kt
+++ b/app/src/main/java/com/example/karaoke_note/AppBar.kt
@@ -23,7 +23,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.FilterAlt
@@ -123,7 +123,7 @@ fun AppBar(
                         navController.navigateUp()
                     }
                 ) {
-                    Icon(Icons.Filled.ArrowBack, contentDescription = null)
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
                 }
             }
         },

--- a/app/src/main/java/com/example/karaoke_note/AppBar.kt
+++ b/app/src/main/java/com/example/karaoke_note/AppBar.kt
@@ -129,7 +129,7 @@ fun AppBar(
         actions = {
             Row(
                 modifier = Modifier.align(alignment = Alignment.CenterVertically),
-                //horizontalArrangement = Arrangement.End
+                horizontalArrangement = Arrangement.End
             ) {
                 // 検索ウインドウ
                 CustomTextField(
@@ -138,7 +138,7 @@ fun AppBar(
                     placeholder = { Text(text = "検索") },
                     modifier = Modifier
                         .weight(1f)
-                        .padding(end = 8.dp)
+                        .padding(start = 4.dp, end = 8.dp)
                         .focusRequester(focusRequesterForSearchBar),
                     singleLine = true,
                     leadingIcon = {

--- a/app/src/main/java/com/example/karaoke_note/AppBar.kt
+++ b/app/src/main/java/com/example/karaoke_note/AppBar.kt
@@ -33,12 +33,12 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.FilterAlt
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
-import androidx.compose.material3.Divider
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -290,7 +290,7 @@ fun FilterContents(
             FilterContentGroup(label = "JOY", filterSetting.value.joySelected, filterSetting.value.joyGameSelected)
             FilterContentGroup(label = "DAM", filterSetting.value.damSelected, filterSetting.value.damGameSelected)
         }
-        Divider(thickness = 1.dp, color = MaterialTheme.colorScheme.outlineVariant)
+        HorizontalDivider(thickness = 1.dp, color = MaterialTheme.colorScheme.outlineVariant)
     }
 }
 

--- a/app/src/main/java/com/example/karaoke_note/ArtistsList.kt
+++ b/app/src/main/java/com/example/karaoke_note/ArtistsList.kt
@@ -313,7 +313,7 @@ fun ArtistListItem(
     }
 
     val haptics = LocalHapticFeedback.current
-    var iconColorSelectorOpened by remember { mutableStateOf(false) }
+    var iconSelectorOpened by remember { mutableStateOf(false) }
 
     // アーティストごとに曲数を取得する
     val songsListFlow = songDao.getSongsWithScores(artist.id)
@@ -347,7 +347,7 @@ fun ArtistListItem(
                         onLongClick = {
                             clearFocusFromSearchBar(focusManagerOfSearchBar)
                             haptics.performHapticFeedback(HapticFeedbackType.LongPress)
-                            iconColorSelectorOpened = true
+                            iconSelectorOpened = true
                         }
                     )
                 )
@@ -359,7 +359,7 @@ fun ArtistListItem(
         )
     }
 
-    if (iconColorSelectorOpened) { // これもできれば切り出したいな
+    if (iconSelectorOpened) { // これもできれば切り出したいな
         Card(
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(4.dp)
@@ -374,7 +374,7 @@ fun ArtistListItem(
                         onClick = {
                             clearFocusFromSearchBar(focusManagerOfSearchBar)
                             updateArtistIcon(artist.id, index)
-                            iconColorSelectorOpened = false
+                            iconSelectorOpened = false
                         },
                         modifier = Modifier
                             .weight(1f)   // 均等に

--- a/app/src/main/java/com/example/karaoke_note/ArtistsList.kt
+++ b/app/src/main/java/com/example/karaoke_note/ArtistsList.kt
@@ -31,8 +31,8 @@ import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.material.icons.outlined.Circle
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
@@ -353,7 +353,7 @@ fun ArtistListItem(
                 )
             }
         )
-        Divider(
+        HorizontalDivider(
             color = MaterialTheme.colorScheme.outlineVariant,
             thickness = 1.dp
         )

--- a/app/src/main/java/com/example/karaoke_note/BottomNavBar.kt
+++ b/app/src/main/java/com/example/karaoke_note/BottomNavBar.kt
@@ -1,8 +1,8 @@
 package com.example.karaoke_note
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.List
-import androidx.compose.material.icons.filled.PlaylistAdd
+import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
@@ -43,13 +43,13 @@ fun BottomNavigationBar(navController: NavController, songScoreDao: SongScoreDao
         BottomNavItem(
             name = "Plans",
             route = "plans",
-            icon = Icons.Filled.PlaylistAdd,
+            icon = Icons.AutoMirrored.Filled.PlaylistAdd,
             badge = plansBadge
         ),
         BottomNavItem(
             name = "List",
             route = "list",
-            icon = Icons.Filled.List,
+            icon = Icons.AutoMirrored.Filled.List,
         )
     )
 

--- a/app/src/main/java/com/example/karaoke_note/MainActivity.kt
+++ b/app/src/main/java/com/example/karaoke_note/MainActivity.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.Surface
+import androidx.compose.material3.Surface
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold

--- a/app/src/main/java/com/example/karaoke_note/Plans.kt
+++ b/app/src/main/java/com/example/karaoke_note/Plans.kt
@@ -10,11 +10,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+//noinspection UsingMaterialAndMaterial3Libraries
 import androidx.compose.material.DismissDirection
+//noinspection UsingMaterialAndMaterial3Libraries
 import androidx.compose.material.DismissValue
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Delete
+//noinspection UsingMaterialAndMaterial3Libraries
 import androidx.compose.material.rememberDismissState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon

--- a/app/src/main/java/com/example/karaoke_note/Plans.kt
+++ b/app/src/main/java/com/example/karaoke_note/Plans.kt
@@ -1,26 +1,16 @@
 package com.example.karaoke_note
 
-import androidx.compose.foundation.background
+//noinspection UsingMaterialAndMaterial3Libraries
+//noinspection UsingMaterialAndMaterial3Libraries
+//noinspection UsingMaterialAndMaterial3Libraries
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-//noinspection UsingMaterialAndMaterial3Libraries
-import androidx.compose.material.DismissDirection
-//noinspection UsingMaterialAndMaterial3Libraries
-import androidx.compose.material.DismissValue
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Delete
-//noinspection UsingMaterialAndMaterial3Libraries
-import androidx.compose.material.rememberDismissState
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarDuration
@@ -30,7 +20,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -41,7 +30,7 @@ import com.example.karaoke_note.data.Song
 import com.example.karaoke_note.data.SongDao
 import com.example.karaoke_note.data.SongScore
 import com.example.karaoke_note.data.SongScoreDao
-import com.example.karaoke_note.ui.component.CustomSwipeToDismiss
+import com.example.karaoke_note.ui.component.DraggableBox
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.time.LocalDate
@@ -131,6 +120,7 @@ fun PlansPage(
                     if (song != null) {
                         val artist = artistDao.getNameById(song.artistId)
                         if (artist != null) {
+                            /*
                             val dismissState = rememberDismissState(
                                 confirmStateChange = {
                                     if (songScoreList.isNotEmpty() && it == DismissValue.DismissedToStart) {
@@ -153,6 +143,35 @@ fun PlansPage(
                                 }
                             )
 
+                             */
+
+                            DraggableBox(
+                                modifier = Modifier,
+                                onDelete = {
+                                    if (songScoreList.isNotEmpty()) {
+                                        // Plan データを削除する
+                                        removePlansListItem(
+                                            artistId = song.artistId,
+                                            songId = songScore.songId,
+                                            scoreId = songScore.id,
+                                            artistDao = artistDao,
+                                            songDao = songDao,
+                                            songScoreDao = songScoreDao,
+                                            scope = scope,
+                                            snackBarHostState = snackBarHostState
+                                        )
+                                        true    // スワイプして songScore が消える
+                                    }
+                                    else {
+                                        false   // スワイプして元に戻る
+                                    }
+                                }
+                            ) {
+                                PlansListItem(song, songScore, artist, showEntrySheetDialog, editingSongScore)
+                            }
+
+
+                            /*
                             CustomSwipeToDismiss(
                                 state = dismissState,
                                 modifier = Modifier,
@@ -164,6 +183,8 @@ fun PlansPage(
                                     PlansListItem(song, songScore, artist, showEntrySheetDialog, editingSongScore)
                                 }
                             )
+
+                             */
                         }
                     }
                     else {
@@ -174,7 +195,7 @@ fun PlansPage(
         }
     }
 }
-
+/*
 // SwipeToDismissBox の背面に表示されるコンテンツ (ゴミ箱)
 @Composable
 fun BackGroundItem() {
@@ -199,6 +220,7 @@ fun BackGroundItem() {
         HorizontalDivider(thickness = 1.dp, color = MaterialTheme.colorScheme.errorContainer)
     }
 }
+*/
 
 @Composable
 fun PlansListItem(

--- a/app/src/main/java/com/example/karaoke_note/Plans.kt
+++ b/app/src/main/java/com/example/karaoke_note/Plans.kt
@@ -175,9 +175,10 @@ fun PlansPage(
     }
 }
 
+// SwipeToDismissBox の背面に表示されるコンテンツ (ゴミ箱)
 @Composable
 fun BackGroundItem() {
-    Column(modifier = Modifier) {
+    Column {
         Box(
             modifier = Modifier
                 .padding()

--- a/app/src/main/java/com/example/karaoke_note/SongList.kt
+++ b/app/src/main/java/com/example/karaoke_note/SongList.kt
@@ -11,7 +11,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -187,7 +187,7 @@ fun SongList(
                 )
             }
         }
-        Divider(
+        HorizontalDivider(
             color = MaterialTheme.colorScheme.outlineVariant,
             thickness = 1.dp
         )

--- a/app/src/main/java/com/example/karaoke_note/SongScores.kt
+++ b/app/src/main/java/com/example/karaoke_note/SongScores.kt
@@ -12,17 +12,18 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.DropdownMenu
-import androidx.compose.material.DropdownMenuItem
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.TextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material3.Divider
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
@@ -162,24 +163,38 @@ fun SongScores(
                             expanded.value = false
                             showEntrySheetDialog.value = true
                             editingSongScore.value = songScore
-                        }
-                    ) {
-                        Text(
-                            text = "編集",
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                    }
+                        },
+                        text = {
+                            Text(
+                                text = "編集",
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        },
+                        modifier = Modifier,
+                        leadingIcon = null,
+                        trailingIcon = null,
+                        enabled = true,
+                        colors = MenuDefaults.itemColors(),
+                        contentPadding = MenuDefaults.DropdownMenuItemContentPadding
+                    )
                     DropdownMenuItem(
                         onClick = {
                             selectedScoreId.value?.let { songScoreDao.deleteSongScore(it) }
                             expanded.value = false
-                        }
-                    ) {
-                        Text(
-                            text = "削除",
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                    }
+                        },
+                        text = {
+                            Text(
+                                text = "削除",
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        },
+                        modifier = Modifier,
+                        leadingIcon = null,
+                        trailingIcon = null,
+                        enabled = true,
+                        colors = MenuDefaults.itemColors(),
+                        contentPadding = MenuDefaults.DropdownMenuItemContentPadding
+                    )
                 }
             },
             comparator = null,
@@ -227,7 +242,7 @@ fun SongScores(
                 )
             }
         }
-        Divider(
+        HorizontalDivider(
             color = MaterialTheme.colorScheme.outlineVariant,
             thickness = 1.dp
         )

--- a/app/src/main/java/com/example/karaoke_note/SortableTable.kt
+++ b/app/src/main/java/com/example/karaoke_note/SortableTable.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -64,7 +64,7 @@ fun <T> SortableTable(
             sortDirection = newSortDirection
             onHeaderClick()
         }
-        Divider(
+        HorizontalDivider(
             color = MaterialTheme.colorScheme.outlineVariant,
             thickness = 1.dp
         )
@@ -84,7 +84,7 @@ fun <T> SortableTable(
                     onRowClick(item)
                 }
                 if (index < items.size - 1) {
-                    Divider(
+                    HorizontalDivider(
                         color = MaterialTheme.colorScheme.outlineVariant,
                         thickness = 1.dp
                     )

--- a/app/src/main/java/com/example/karaoke_note/data/FilterSetting.kt
+++ b/app/src/main/java/com/example/karaoke_note/data/FilterSetting.kt
@@ -10,7 +10,7 @@ class FilterSetting {
     val damGameSelected: Map<GameKind, MutableState<Boolean>> = GameKind.getDamGameKinds().associateWith { mutableStateOf(true) }
 
     fun getSelectedGameKinds(): List<GameKind> {
-        return GameKind.values().filter { gameKind ->
+        return GameKind.entries.filter { gameKind ->
             when (gameKind) {
                 in joyGameSelected -> joyGameSelected[gameKind]?.value ?: false
                 in damGameSelected -> damGameSelected[gameKind]?.value ?: false

--- a/app/src/main/java/com/example/karaoke_note/data/FilterSetting.kt
+++ b/app/src/main/java/com/example/karaoke_note/data/FilterSetting.kt
@@ -12,8 +12,8 @@ class FilterSetting {
     fun getSelectedGameKinds(): List<GameKind> {
         return GameKind.entries.filter { gameKind ->
             when (gameKind) {
-                in joyGameSelected -> joyGameSelected[gameKind]?.value ?: false
-                in damGameSelected -> damGameSelected[gameKind]?.value ?: false
+                in joyGameSelected -> joyGameSelected[gameKind]?.value == true
+                in damGameSelected -> damGameSelected[gameKind]?.value == true
                 else -> false
             }
         }

--- a/app/src/main/java/com/example/karaoke_note/data/GameKind.kt
+++ b/app/src/main/java/com/example/karaoke_note/data/GameKind.kt
@@ -6,7 +6,7 @@ enum class BrandKind(val displayName: String) {
 
     companion object {
         fun fromDisplayName(displayName: String): BrandKind? {
-            return values().firstOrNull { it.displayName == displayName }
+            return entries.firstOrNull { it.displayName == displayName }
         }
     }
 }
@@ -25,7 +25,7 @@ enum class GameKind(val displayName: String) {
 
     companion object {
         fun fromDisplayName(displayName: String): GameKind? {
-            return values().firstOrNull { it.displayName == displayName }
+            return entries.firstOrNull { it.displayName == displayName }
         }
         fun getBrandKind(gameKind: GameKind): BrandKind {
             return when (gameKind) {
@@ -42,10 +42,10 @@ enum class GameKind(val displayName: String) {
             }
         }
         fun getJoyGameKinds(): List<GameKind> {
-            return values().filter { getBrandKind(it) == BrandKind.JOY }
+            return entries.filter { getBrandKind(it) == BrandKind.JOY }
         }
         fun getDamGameKinds(): List<GameKind> {
-            return values().filter { getBrandKind(it) == BrandKind.DAM }
+            return entries.filter { getBrandKind(it) == BrandKind.DAM }
         }
     }
 }

--- a/app/src/main/java/com/example/karaoke_note/ui/component/CommonTextField.kt
+++ b/app/src/main/java/com/example/karaoke_note/ui/component/CommonTextField.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.IconButton
+import androidx.compose.material3.IconButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Error

--- a/app/src/main/java/com/example/karaoke_note/ui/component/CustomSwipeToDismiss.kt
+++ b/app/src/main/java/com/example/karaoke_note/ui/component/CustomSwipeToDismiss.kt
@@ -1,11 +1,19 @@
 package com.example.karaoke_note.ui.component
 
+import android.annotation.SuppressLint
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.DismissDirection
 import androidx.compose.material.DismissState
 import androidx.compose.material.DismissValue
@@ -14,15 +22,99 @@ import androidx.compose.material.FractionalThreshold
 import androidx.compose.material.ResistanceConfig
 import androidx.compose.material.SwipeableDefaults
 import androidx.compose.material.ThresholdConfig
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.swipeable
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import kotlin.math.roundToInt
 
+
+@SuppressLint("UnusedBoxWithConstraintsScope")
+@Composable
+fun DraggableBox(
+    modifier: Modifier = Modifier,
+    onDelete: () -> Unit,
+    content: @Composable () -> Unit
+){
+    BoxWithConstraints {
+        val density = LocalDensity.current
+        val maxWidth = constraints.maxWidth.toFloat()
+        val percentage = 50
+        val swipeState = rememberSwipeToDismissBoxState(
+            positionalThreshold = {
+                with(density) { (maxWidth * percentage).dp.toPx() }
+            },
+        )
+        var icon: ImageVector
+        var alignment: Alignment
+        var color: Color
+
+        SwipeToDismissBox(
+            state = swipeState,
+            backgroundContent = {
+                Column {
+                    when (swipeState.dismissDirection) {
+                        SwipeToDismissBoxValue.EndToStart -> {
+                            Box(
+                                modifier = Modifier
+                                    .padding()
+                                    .fillMaxWidth()
+                                    .height(80.dp)
+                                    .background(MaterialTheme.colorScheme.errorContainer),
+                                contentAlignment = Alignment.CenterEnd
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Outlined.Delete,
+                                    contentDescription = "delete",
+                                    tint = MaterialTheme.colorScheme.error,
+                                    modifier = Modifier
+                                        .size(60.dp)
+                                        .padding(end = 30.dp)
+                                )
+                            }
+                        }
+                        SwipeToDismissBoxValue.StartToEnd -> {}
+                        SwipeToDismissBoxValue.Settled -> {}
+                    }
+                    HorizontalDivider(
+                        thickness = 1.dp,
+                        color = MaterialTheme.colorScheme.errorContainer
+                    )
+                }
+            },
+            modifier = modifier.animateContentSize(),
+            enableDismissFromStartToEnd = false
+        ) {
+            content()
+        }
+
+        when (swipeState.currentValue) {
+            SwipeToDismissBoxValue.EndToStart -> {
+                onDelete()
+            }
+            SwipeToDismissBoxValue.StartToEnd -> {}
+            SwipeToDismissBoxValue.Settled -> {}
+        }
+    }
+}
+
+
+@SuppressLint("UnusedBoxWithConstraintsScope")
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun CustomSwipeToDismiss(

--- a/app/src/main/java/com/example/karaoke_note/ui/component/CustomSwipeToDismiss.kt
+++ b/app/src/main/java/com/example/karaoke_note/ui/component/CustomSwipeToDismiss.kt
@@ -34,8 +34,6 @@ import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntOffset
@@ -60,9 +58,6 @@ fun DraggableBox(
                 with(density) { (maxWidth * percentage).dp.toPx() }
             },
         )
-        var icon: ImageVector
-        var alignment: Alignment
-        var color: Color
 
         SwipeToDismissBox(
             state = swipeState,

--- a/app/src/main/java/com/example/karaoke_note/ui/component/SongScoreDetailDialog.kt
+++ b/app/src/main/java/com/example/karaoke_note/ui/component/SongScoreDetailDialog.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.window.Dialog
 import com.example.karaoke_note.data.SongScore
 import com.example.karaoke_note.getPainterResourceIdOfGameImage
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 //
 // 結果の詳細表示用ダイアログ
@@ -88,7 +89,7 @@ fun SongScoreDetailDialog(
                                 fontSize = fontSizeSmall.sp
                             )
                             Text(
-                                text = String.format("%.3f", songScore.score),
+                                text = String.format(Locale.US, "%.3f", songScore.score),
                                 modifier = Modifier.padding(),
                                 fontSize = fontSizeLarge.sp
                             )

--- a/app/src/main/java/com/example/karaoke_note/ui/component/SortMethodSelector.kt
+++ b/app/src/main/java/com/example/karaoke_note/ui/component/SortMethodSelector.kt
@@ -3,13 +3,14 @@ package com.example.karaoke_note.ui.component
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowDropUp
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -30,7 +31,7 @@ enum class SortMethod(val displayName: String) {
 
     companion object {
         fun fromDisplayName(displayName: String): SortMethod? {
-            return SortMethod.values().firstOrNull { it.displayName == displayName }
+            return entries.firstOrNull { it.displayName == displayName }
         }
     }
 }
@@ -89,12 +90,19 @@ fun SortMethodSelectorItem(
 
     DropdownMenuItem(
         onClick = { onClick() },
-    ) {
-        Text(
-            text = sortMethod.displayName,
-            color = fontColor,
-            fontSize = textSize.sp,
-            fontWeight = fontWeight,
-        )
-    }
+        text = {
+            Text(
+                text = sortMethod.displayName,
+                color = fontColor,
+                fontSize = textSize.sp,
+                fontWeight = fontWeight,
+            )
+        },
+        modifier = Modifier,
+        leadingIcon = null,
+        trailingIcon = null,
+        enabled = true,
+        colors = MenuDefaults.itemColors(),
+        contentPadding = MenuDefaults.DropdownMenuItemContentPadding,
+    )
 }

--- a/app/src/main/java/com/example/karaoke_note/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/karaoke_note/ui/theme/Theme.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
@@ -56,7 +55,7 @@ fun Karaoke_noteTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
+            //window.statusBarColor = colorScheme.primary.toArgb()
             WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -6,4 +6,5 @@ plugins {
     id 'org.jlleitschuh.gradle.ktlint' version '11.6.1'
     id 'io.gitlab.arturbosch.detekt' version '1.23.3'
     id 'org.jetbrains.kotlin.plugin.compose' version '2.1.0' apply false
+    id 'com.google.devtools.ksp' version "2.1.20-2.0.1" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
前回のバージョンアップに伴って各ファイルにそこそこ大量の Warning が出ていたので、主にそれらの解消をしています。以下、問題点

(1) ExposedDropdownMenuBox() において非推奨になった Modifier.menuAnchor の代替について、サンプルコードを見つけられなかったために残っている。
(2) Plans.kt と CustomSwipeToDismiss.kt にコメントアウトがいっぱいある。一応戻せるように旧来の関数等が残っているので Warning もたくさん出る。(git の機能で戻せよって？慣れないことをすると痛い目に遭う)
(3) CustomSwipeToDismiss() にある Modifier.swipeable は非推奨になった。これを anchoredDraggable で置き換えるようだが、出たばかりでサンプルコードが少なくうまく書けなかったので妥協した。そのせいで velocityThreshold を設定できなくなり、普通の速度感でスワイプすると削除判定されてしまう。
(4) velocityThreshold を設定できるようにするために SwipeToDismissBox.kt を丸ごとコピーする手も考えられたが、なぜかエラーが出てしまうので実現できなかった。
(5) 最後に気付いたが、TopAppBar 左端にあるべき ArrowBack が消えてしまう。どうも検索バーが長くなっているようだが、その辺のコードは変わっていないはず。