### PR TITLE
設定画面の仮実装

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
+    //id 'org.jetbrains.kotlin.android'
     id 'com.google.devtools.ksp'
     id 'org.jetbrains.kotlin.plugin.compose'
 }
@@ -9,9 +9,10 @@ android {
     namespace = 'com.example.karaoke_note'
     compileSdk = 36
 
-    kotlin {
+/*    kotlin {
         jvmToolchain(21)
     }
+ */
     defaultConfig {
         applicationId "com.example.karaoke_note"
         minSdk = 31
@@ -43,38 +44,44 @@ android {
         }
     }
 }
+/*
+kotlin {
+    jvmToolchain(21)
+}
+ */
+
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.17.0'
-    implementation platform('org.jetbrains.kotlin:kotlin-bom:2.2.0')
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.9.4'
-    implementation 'androidx.activity:activity-compose:1.11.0'
-    implementation platform('androidx.compose:compose-bom:2025.11.00')
-    implementation 'androidx.compose.ui:ui'
-    implementation 'androidx.compose.ui:ui-graphics'
-    implementation 'androidx.compose.ui:ui-tooling-preview'
-    implementation 'androidx.compose.material3:material3:1.4.0'
-    implementation 'androidx.compose.material:material:1.9.4'
-    implementation 'androidx.compose.material:material-icons-extended:1.7.8'
-    implementation 'androidx.datastore:datastore-preferences-android:1.1.7'
-    implementation 'androidx.datastore:datastore-core-android:1.1.7'
+implementation 'androidx.core:core-ktx:1.18.0'
+implementation platform('org.jetbrains.kotlin:kotlin-bom:2.2.0')
+implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.10.0'
+implementation 'androidx.activity:activity-compose:1.13.0'
+implementation platform('androidx.compose:compose-bom:2026.03.00')
+implementation 'androidx.compose.ui:ui'
+implementation 'androidx.compose.ui:ui-graphics'
+implementation 'androidx.compose.ui:ui-tooling-preview'
+implementation 'androidx.compose.material3:material3:1.4.0'
+implementation 'androidx.compose.material:material:1.10.5'
+implementation 'androidx.compose.material:material-icons-extended:1.7.8'
+implementation 'androidx.datastore:datastore-preferences-android:1.2.1'
+implementation 'androidx.datastore:datastore-core-android:1.2.1'
 
-    def nav_version = '2.9.0'
-    implementation "androidx.navigation:navigation-compose:$nav_version"
+def nav_version = '2.9.0'
+implementation "androidx.navigation:navigation-compose:$nav_version"
 
-    def room_version = '2.8.3'
-    implementation "androidx.room:room-runtime:$room_version"
-    annotationProcessor "androidx.room:room-compiler:$room_version"
-    ksp "androidx.room:room-compiler:$room_version"
-    //noinspection GradleDependency
-    implementation "androidx.room:room-ktx:$room_version"
-    implementation 'com.google.code.gson:gson:2.13.2'
+def room_version = '2.8.3'
+implementation "androidx.room:room-runtime:$room_version"
+annotationProcessor "androidx.room:room-compiler:$room_version"
+ksp "androidx.room:room-compiler:$room_version"
+//noinspection GradleDependency
+implementation "androidx.room:room-ktx:$room_version"
+implementation 'com.google.code.gson:gson:2.13.2'
 
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
-    androidTestImplementation platform('androidx.compose:compose-bom:2025.11.00')
-    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
-    debugImplementation 'androidx.compose.ui:ui-tooling'
-    debugImplementation 'androidx.compose.ui:ui-test-manifest:1.9.4'
+testImplementation 'junit:junit:4.13.2'
+androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
+androidTestImplementation platform('androidx.compose:compose-bom:2026.03.00')
+androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+debugImplementation 'androidx.compose.ui:ui-tooling'
+debugImplementation 'androidx.compose.ui:ui-test-manifest:1.10.5'
 }

--- a/app/src/main/java/com/example/karaoke_note/AppBar.kt
+++ b/app/src/main/java/com/example/karaoke_note/AppBar.kt
@@ -1,12 +1,5 @@
 package com.example.karaoke_note
 
-import android.app.Activity
-import android.content.Context
-import android.content.Intent
-import android.provider.DocumentsContract
-import android.util.Log
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.border
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -27,13 +20,10 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.FilterAlt
 import androidx.compose.material.icons.filled.Games
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.FilterAlt
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
@@ -43,7 +33,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -66,27 +55,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import com.example.karaoke_note.data.Artist
 import com.example.karaoke_note.data.ArtistDao
-import com.example.karaoke_note.data.DATABASE_VERSION
 import com.example.karaoke_note.data.FilterSetting
 import com.example.karaoke_note.data.GameKind
-import com.example.karaoke_note.data.Song
 import com.example.karaoke_note.data.SongDao
-import com.example.karaoke_note.data.SongScore
 import com.example.karaoke_note.data.SongScoreDao
 import com.example.karaoke_note.ui.component.CustomTextField
-import com.google.gson.Gson
-import com.google.gson.GsonBuilder
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonSerializer
-import java.io.BufferedWriter
-import java.io.OutputStreamWriter
-import java.text.SimpleDateFormat
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
-import java.util.Date
-import java.util.Locale
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -102,8 +76,8 @@ fun AppBar(
     focusManagerOfSearchBar: FocusManager
 ) {
     val canPop = remember { mutableStateOf(false) }
-    val showMenu = remember { mutableStateOf(false) }
     var showSheet by remember { mutableStateOf(false) }
+    var showSettings by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState()
 
     LaunchedEffect(navController) {
@@ -208,14 +182,15 @@ fun AppBar(
                     IconButton(
                         onClick = {
                             clearFocusFromSearchBar(focusManagerOfSearchBar)
-                            showMenu.value = true
+                            showSettings = true
                         }
                     ) {
                         Icon(
-                            imageVector = Icons.Filled.MoreVert,
-                            contentDescription = "メニュー"
+                            imageVector = Icons.Filled.Settings,
+                            contentDescription = "Settings"
                         )
                     }
+                    /*
                     DropdownMenu(
                         expanded = showMenu.value,
                         onDismissRequest = { showMenu.value = false }
@@ -227,6 +202,7 @@ fun AppBar(
                             showMenu.value = false
                         }
                     }
+                    */
                 }
             }
         },
@@ -234,6 +210,7 @@ fun AppBar(
         scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
     )
 
+    // 下から上がってくるフィルター用画面
     if (showSheet) {
         ModalBottomSheet(
             onDismissRequest = { showSheet = false },
@@ -248,6 +225,13 @@ fun AppBar(
         ) {
             // Sheet content
             FilterContents(filterSetting)
+        }
+    }
+
+    // 設定画面
+    if (showSettings) {
+        SettingScreen(navController, songDao, songScoreDao,artistDao) {
+            showSettings = false
         }
     }
 }
@@ -359,191 +343,6 @@ fun FilterContent(
             }
         } else {
             null
-        }
-    )
-}
-
-
-private fun generateFileName(): String {
-    val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
-    val date = dateFormat.format(Date())
-    return "karaoke_note_backup_$date.json"
-}
-
-@Composable
-fun ExportMenu(
-    songDao: SongDao,
-    songScoreDao: SongScoreDao,
-    artistDao: ArtistDao,
-    context: Context,
-    onClick: () -> Unit = {}
-) {
-    val filePickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.StartActivityForResult()
-    ) { result ->
-        if (result.resultCode == Activity.RESULT_OK) {
-            val selectedFolderUri = result.data?.data
-            // ログに選択されたファイルのパスを表示
-            Log.d("FolderPicker", "Selected folder: $selectedFolderUri")
-            val songScores = songScoreDao.getAll()
-            val songs = songDao.getAllSongs()
-            val artists = artistDao.getAllArtists()
-
-            // LocalDate型のカスタムシリアライザ
-            val localDateSerializer = JsonSerializer<LocalDate> { src, _, _ ->
-                Gson().toJsonTree(src.format(DateTimeFormatter.ISO_LOCAL_DATE))
-            }
-
-            // Gsonインスタンスの作成
-            val gson = GsonBuilder()
-                .registerTypeAdapter(LocalDate::class.java, localDateSerializer)
-                .create()
-
-            // エクスポートするデータ構造
-            val exportData = mapOf(
-                "version" to DATABASE_VERSION,
-                "songScores" to songScores,
-                "songs" to songs,
-                "artists" to artists
-            )
-            val json = gson.toJson(exportData)
-
-            try {
-                val documentUri = DocumentsContract.buildDocumentUriUsingTree(
-                    selectedFolderUri,
-                    DocumentsContract.getTreeDocumentId(selectedFolderUri)
-                )
-
-                val jsonFileUri = DocumentsContract.createDocument(
-                    context.contentResolver,
-                    documentUri,
-                    "application/json",
-                    generateFileName()
-                )
-                if (jsonFileUri == null) {
-                    Log.e("FolderPicker", "Error creating JSON file")
-                } else {
-                    context.contentResolver.openOutputStream(jsonFileUri).use { outputStream ->
-                        BufferedWriter(OutputStreamWriter(outputStream)).use { writer ->
-                            writer.write(json)
-                        }
-                    }
-                }
-                Log.d("FolderPicker", "JSON file saved successfully")
-            } catch (e: Exception) {
-                Log.e("FolderPicker", "Error saving JSON file", e)
-            }
-        }
-        onClick()
-    }
-    DropdownMenuItem(
-        text = {
-            Text("データのエクスポート")
-        },
-        onClick = {
-            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
-            filePickerLauncher.launch(intent)
-        }
-    )
-}
-
-@Composable
-fun ImportMenu(
-    songDao: SongDao,
-    songScoreDao: SongScoreDao,
-    artistDao: ArtistDao,
-    context: Context,
-    onClick: () -> Unit = {}
-) {
-    val localDateDeserializer = JsonDeserializer { json, _, _ ->
-        LocalDate.parse(json.asJsonPrimitive.asString, DateTimeFormatter.ISO_LOCAL_DATE)
-    }
-
-    val gson = GsonBuilder()
-        .registerTypeAdapter(LocalDate::class.java, localDateDeserializer)
-        .create()
-
-    var showDialog by remember { mutableStateOf(false) }
-    val filePickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.StartActivityForResult()
-    ) { result ->
-        if (result.resultCode == Activity.RESULT_OK) {
-            val selectedFileUri = result.data?.data
-            // ログに選択されたファイルのパスを表示
-            Log.d("FilePicker", "Selected file: $selectedFileUri")
-            try {
-                context.contentResolver.openInputStream(selectedFileUri!!).use { inputStream ->
-                    val json = inputStream?.bufferedReader().use { it?.readText() }
-                    Log.d("FilePicker", "JSON file loaded successfully")
-                    Log.d("FilePicker", json!!)
-                    data class JsonVersion(
-                        val version: Int
-                    )
-                    val versionInfo = gson.fromJson(json, JsonVersion::class.java)
-                    when (versionInfo.version) {
-                        4 -> {
-                            data class JsonDataV3(
-                                val version: Int,
-                                val songScores: List<SongScore>,
-                                val songs: List<Song>,
-                                val artists: List<Artist>
-                            )
-                            val jsonDataV3 = gson.fromJson(json, JsonDataV3::class.java)
-
-                            // IDが混在するとおかしくなるのでデータベースをクリア
-                            songDao.clearAllSongs()
-                            songScoreDao.clearAllSongScores()
-                            artistDao.clearAllArtists()
-
-                            // データベースにインポート
-                            songDao.insertAll(jsonDataV3.songs)
-                            songScoreDao.insertAll(jsonDataV3.songScores)
-                            artistDao.insertAll(jsonDataV3.artists)
-                        }
-                        else -> {
-                            throw IllegalArgumentException("Unsupported version: ${versionInfo.version}")
-                        }
-                    }
-                }
-            } catch (e: Exception) {
-                Log.e("FilePicker", "Error loading JSON file", e)
-            }
-        }
-        onClick()
-    }
-
-    if (showDialog) {
-        AlertDialog(
-            onDismissRequest = { showDialog = false },
-            title = { Text("確認") },
-            text = { Text("すべてのデータは失われますがよろしいですか？") },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        showDialog = false
-                        // ファイルピッカーを起動
-                        val intent = Intent(Intent.ACTION_GET_CONTENT).apply {
-                            type = "application/json"
-                        }
-                        filePickerLauncher.launch(intent)
-                    }
-                ) {
-                    Text("はい")
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showDialog = false }) {
-                    Text("いいえ")
-                }
-            }
-        )
-    }
-    DropdownMenuItem(
-        text = {
-            Text("データのインポート")
-        },
-        onClick = {
-            showDialog = true
         }
     )
 }

--- a/app/src/main/java/com/example/karaoke_note/AppBar.kt
+++ b/app/src/main/java/com/example/karaoke_note/AppBar.kt
@@ -73,7 +73,8 @@ fun AppBar(
     filterSetting: MutableState<FilterSetting>,
     searchText: MutableState<String>,
     focusRequesterForSearchBar: FocusRequester,
-    focusManagerOfSearchBar: FocusManager
+    focusManagerOfSearchBar: FocusManager,
+    isBackKeyDisabled: MutableState<Boolean>
 ) {
     val canPop = remember { mutableStateOf(false) }
     var showSheet by remember { mutableStateOf(false) }
@@ -154,7 +155,9 @@ fun AppBar(
                         unfocusedIndicatorColor = Color.Transparent,
                         disabledIndicatorColor = Color.Transparent
                     ),
-                    contentPadding = TextFieldDefaults.contentPaddingWithoutLabel(0.dp, 0.dp, 0.dp, 0.dp)
+                    contentPadding = TextFieldDefaults.contentPaddingWithoutLabel(
+                        0.dp, 0.dp, 0.dp, 0.dp
+                    )
                 )
 
                 // フィルターボタン
@@ -175,7 +178,7 @@ fun AppBar(
                     )
                 }
 
-                // メニューボタン
+                // 設定ボタン
                 Box(
                     contentAlignment = Alignment.BottomEnd
                 ) {
@@ -187,22 +190,10 @@ fun AppBar(
                     ) {
                         Icon(
                             imageVector = Icons.Filled.Settings,
-                            contentDescription = "Settings"
+                            contentDescription = "Settings",
+                            tint = MaterialTheme.colorScheme.primary
                         )
                     }
-                    /*
-                    DropdownMenu(
-                        expanded = showMenu.value,
-                        onDismissRequest = { showMenu.value = false }
-                    ) {
-                        ImportMenu(songDao, songScoreDao, artistDao, navController.context) {
-                            showMenu.value = false
-                        }
-                        ExportMenu(songDao, songScoreDao, artistDao, navController.context) {
-                            showMenu.value = false
-                        }
-                    }
-                    */
                 }
             }
         },
@@ -230,7 +221,7 @@ fun AppBar(
 
     // 設定画面
     if (showSettings) {
-        SettingScreen(navController, songDao, songScoreDao,artistDao) {
+        SettingScreen(navController, songDao, songScoreDao, artistDao, isBackKeyDisabled) {
             showSettings = false
         }
     }

--- a/app/src/main/java/com/example/karaoke_note/BottomNavBar.kt
+++ b/app/src/main/java/com/example/karaoke_note/BottomNavBar.kt
@@ -30,7 +30,10 @@ data class BottomNavItem(
 
 @ExperimentalMaterial3Api
 @Composable
-fun BottomNavigationBar(navController: NavController, songScoreDao: SongScoreDao) {
+fun BottomNavigationBar(
+    navController: NavController,
+    songScoreDao: SongScoreDao
+) {
     val songDataFlow = songScoreDao.getAll0Scores()
     val songDataList by songDataFlow.collectAsState(initial = listOf())
     val plansBadge = songDataList.size

--- a/app/src/main/java/com/example/karaoke_note/MainActivity.kt
+++ b/app/src/main/java/com/example/karaoke_note/MainActivity.kt
@@ -62,6 +62,8 @@ class MainActivity : ComponentActivity() {
                 // SearchBar に対するフォーカスの変更を管理する
                 val focusRequesterForSearchBar = remember { FocusRequester() }
                 val focusManagerOfSearchBar = LocalFocusManager.current
+                // 標準の戻るキーが無効かどうか
+                val isBackKeyDisabled = remember { mutableStateOf(false) }
 
                 // A surface container using the 'background' color from the theme
                 Surface(
@@ -72,7 +74,7 @@ class MainActivity : ComponentActivity() {
                     Scaffold(
                         topBar = {
                             Column {
-                                AppBar(navController, songDao, songScoreDao, artistDao, filterSetting, searchText, focusRequesterForSearchBar, focusManagerOfSearchBar)
+                                AppBar(navController, songDao, songScoreDao, artistDao, filterSetting, searchText, focusRequesterForSearchBar, focusManagerOfSearchBar, isBackKeyDisabled)
                                 Breadcrumbs(navController, focusManagerOfSearchBar, songDao, artistDao)
                             }
                         },
@@ -80,7 +82,7 @@ class MainActivity : ComponentActivity() {
                             BottomNavigationBar(navController, songScoreDao)
                         },
                         floatingActionButton = {
-                            NewEntryScreen(navController, songDao, songScoreDao, artistDao, lifecycleScope, showDialog, editingSongScore, snackBarHostState, focusManagerOfSearchBar)
+                            NewEntryScreen(navController, songDao, songScoreDao, artistDao, lifecycleScope, showDialog, isBackKeyDisabled,editingSongScore, snackBarHostState, focusManagerOfSearchBar)
                         },
                         snackbarHost = {
                             SnackbarHost(snackBarHostState)

--- a/app/src/main/java/com/example/karaoke_note/NewEntrySheet.kt
+++ b/app/src/main/java/com/example/karaoke_note/NewEntrySheet.kt
@@ -205,6 +205,7 @@ fun NewEntryScreen(
     artistDao: ArtistDao,
     scope: CoroutineScope,
     screenOpened: MutableState<Boolean>,
+    isBackKeyDisabled: MutableState<Boolean>,
     editingSongScoreState: MutableState<SongScore?>,
     snackBarHostState: SnackbarHostState,
     focusManagerOfSearchBar: FocusManager
@@ -312,9 +313,11 @@ fun NewEntryScreen(
             ) {
                 // 誤爆防止のため、ここに限って標準のバックキー操作を無効化
                 // 設定メニューで ON/OFF できるようにできればいいな
-                BackHandler(enabled = true) {
-                    // バックキーを押すたびに出てしまうのが鬱陶しい
-                    Toast.makeText(context, "Back key is disabled.", Toast.LENGTH_SHORT).show()
+                if (isBackKeyDisabled.value) {
+                    BackHandler(enabled = true) {
+                        // バックキーを押すたびに出てしまうのが鬱陶しい
+                        Toast.makeText(context, "Back key is disabled.", Toast.LENGTH_SHORT).show()
+                    }
                 }
 
                 Column {

--- a/app/src/main/java/com/example/karaoke_note/Setting.kt
+++ b/app/src/main/java/com/example/karaoke_note/Setting.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -63,11 +64,11 @@ fun SettingScreen(
     songDao: SongDao,
     songScoreDao: SongScoreDao,
     artistDao: ArtistDao,
+    isBackKeyDisabled: MutableState<Boolean>,
     onNavigateBack: () -> Unit // 戻るボタンが押されたときのコールバック
 ) {
     // 各Switchの状態を管理する
-    var switch1 by remember { mutableStateOf(true) }
-    var switch2 by remember { mutableStateOf(false) }
+    val switch2 = remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -93,26 +94,22 @@ fun SettingScreen(
             // 1つ目のSwitch設定
             SettingItemRow(
                 title = "登録画面において戻るボタンを無効化する",
-                checked = switch1,
-                onCheckedChanged = { switch1 = it }
+                checked = isBackKeyDisabled,
+                onCheckedChanged = { isBackKeyDisabled.value = it }
             )
 
             // 2つ目のSwitch設定
             SettingItemRow(
                 title = "(仮)ダークモードを有効にする",
                 checked = switch2,
-                onCheckedChanged = { switch2 = it }
+                onCheckedChanged = { switch2.value = it }
             )
             Spacer(modifier = Modifier.height(32.dp))
 
-            ImportMenu(songDao, songScoreDao, artistDao, navController.context) {
-                //showMenu.value = false
-            }
+            ImportMenu(songDao, songScoreDao, artistDao, navController.context) {}
             Spacer(modifier = Modifier.height(16.dp))
 
-            ExportMenu(songDao, songScoreDao, artistDao, navController.context) {
-                //showMenu.value = false
-            }
+            ExportMenu(songDao, songScoreDao, artistDao, navController.context) {}
 
         }
     }
@@ -121,7 +118,7 @@ fun SettingScreen(
 @Composable
 fun SettingItemRow(
     title: String,
-    checked: Boolean,
+    checked: MutableState<Boolean>,
     onCheckedChanged: (Boolean) -> Unit
 ) {
     Row(
@@ -136,7 +133,7 @@ fun SettingItemRow(
             style = MaterialTheme.typography.bodyLarge
         )
         Switch(
-            checked = checked,
+            checked = checked.value,
             onCheckedChange = onCheckedChanged
         )
     }

--- a/app/src/main/java/com/example/karaoke_note/Setting.kt
+++ b/app/src/main/java/com/example/karaoke_note/Setting.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -67,8 +66,6 @@ fun SettingScreen(
                 onCheckedChanged = { switch1 = it }
             )
 
-            HorizontalDivider()
-
             // 2つ目のSwitch設定
             SettingItemRow(
                 title = "ダークモードを有効にする",
@@ -85,8 +82,6 @@ fun SettingScreen(
             ) {
                 Text("アカウント設定")
             }
-
-            HorizontalDivider()
 
             // 2つ目のTextButton
             TextButton(

--- a/app/src/main/java/com/example/karaoke_note/Setting.kt
+++ b/app/src/main/java/com/example/karaoke_note/Setting.kt
@@ -1,6 +1,14 @@
 package com.example.karaoke_note
 
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.provider.DocumentsContract
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,6 +18,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -26,12 +35,34 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.example.karaoke_note.data.Artist
+import com.example.karaoke_note.data.ArtistDao
+import com.example.karaoke_note.data.DATABASE_VERSION
+import com.example.karaoke_note.data.Song
+import com.example.karaoke_note.data.SongDao
+import com.example.karaoke_note.data.SongScore
+import com.example.karaoke_note.data.SongScoreDao
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonSerializer
+import java.io.BufferedWriter
+import java.io.OutputStreamWriter
+import java.text.SimpleDateFormat
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Date
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingScreen(
+    navController: NavController,
+    songDao: SongDao,
+    songScoreDao: SongScoreDao,
+    artistDao: ArtistDao,
     onNavigateBack: () -> Unit // 戻るボタンが押されたときのコールバック
 ) {
     // 各Switchの状態を管理する
@@ -61,35 +92,28 @@ fun SettingScreen(
         ) {
             // 1つ目のSwitch設定
             SettingItemRow(
-                title = "通知を有効にする",
+                title = "登録画面において戻るボタンを無効化する",
                 checked = switch1,
                 onCheckedChanged = { switch1 = it }
             )
 
             // 2つ目のSwitch設定
             SettingItemRow(
-                title = "ダークモードを有効にする",
+                title = "(仮)ダークモードを有効にする",
                 checked = switch2,
                 onCheckedChanged = { switch2 = it }
             )
-
             Spacer(modifier = Modifier.height(32.dp))
 
-            // 1つ目のTextButton
-            TextButton(
-                onClick = { /* アカウント設定の処理 */ },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text("アカウント設定")
+            ImportMenu(songDao, songScoreDao, artistDao, navController.context) {
+                //showMenu.value = false
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+
+            ExportMenu(songDao, songScoreDao, artistDao, navController.context) {
+                //showMenu.value = false
             }
 
-            // 2つ目のTextButton
-            TextButton(
-                onClick = { /* 利用規約の表示処理 */ },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text("利用規約")
-            }
         }
     }
 }
@@ -118,9 +142,205 @@ fun SettingItemRow(
     }
 }
 
+/*
 @Preview(showBackground = true)
 @Composable
 fun SettingScreenPreview() {
     // プレビュー用に空のコールバックを渡す
-    SettingScreen(onNavigateBack = {})
+    SettingScreen(songDao, songScoreDao, artistDao, onNavigateBack = {})
+}
+
+ */
+
+private fun generateFileName(): String {
+    val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+    val date = dateFormat.format(Date())
+    return "karaoke_note_backup_$date.json"
+}
+
+@Composable
+fun ExportMenu(
+    songDao: SongDao,
+    songScoreDao: SongScoreDao,
+    artistDao: ArtistDao,
+    context: Context,
+    onClick: () -> Unit = {}
+) {
+    val filePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val selectedFolderUri = result.data?.data
+            // ログに選択されたファイルのパスを表示
+            Log.d("FolderPicker", "Selected folder: $selectedFolderUri")
+            val songScores = songScoreDao.getAll()
+            val songs = songDao.getAllSongs()
+            val artists = artistDao.getAllArtists()
+
+            // LocalDate型のカスタムシリアライザ
+            val localDateSerializer = JsonSerializer<LocalDate> { src, _, _ ->
+                Gson().toJsonTree(src.format(DateTimeFormatter.ISO_LOCAL_DATE))
+            }
+
+            // Gsonインスタンスの作成
+            val gson = GsonBuilder()
+                .registerTypeAdapter(LocalDate::class.java, localDateSerializer)
+                .create()
+
+            // エクスポートするデータ構造
+            val exportData = mapOf(
+                "version" to DATABASE_VERSION,
+                "songScores" to songScores,
+                "songs" to songs,
+                "artists" to artists
+            )
+            val json = gson.toJson(exportData)
+
+            try {
+                val documentUri = DocumentsContract.buildDocumentUriUsingTree(
+                    selectedFolderUri,
+                    DocumentsContract.getTreeDocumentId(selectedFolderUri)
+                )
+
+                val jsonFileUri = DocumentsContract.createDocument(
+                    context.contentResolver,
+                    documentUri,
+                    "application/json",
+                    generateFileName()
+                )
+                if (jsonFileUri == null) {
+                    Log.e("FolderPicker", "Error creating JSON file")
+                } else {
+                    context.contentResolver.openOutputStream(jsonFileUri).use { outputStream ->
+                        BufferedWriter(OutputStreamWriter(outputStream)).use { writer ->
+                            writer.write(json)
+                        }
+                    }
+                }
+                Log.d("FolderPicker", "JSON file saved successfully")
+            } catch (e: Exception) {
+                Log.e("FolderPicker", "Error saving JSON file", e)
+            }
+        }
+        onClick()
+    }
+    Box(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        TextButton(
+            onClick = {
+                val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+                filePickerLauncher.launch(intent)
+            },
+            modifier = Modifier.align(Alignment.Center)
+        ) {
+            Text("データのエクスポート")
+        }
+    }
+}
+
+@Composable
+fun ImportMenu(
+    songDao: SongDao,
+    songScoreDao: SongScoreDao,
+    artistDao: ArtistDao,
+    context: Context,
+    onClick: () -> Unit = {}
+) {
+    val localDateDeserializer = JsonDeserializer { json, _, _ ->
+        LocalDate.parse(json.asJsonPrimitive.asString, DateTimeFormatter.ISO_LOCAL_DATE)
+    }
+
+    val gson = GsonBuilder()
+        .registerTypeAdapter(LocalDate::class.java, localDateDeserializer)
+        .create()
+
+    var showDialog by remember { mutableStateOf(false) }
+    val filePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val selectedFileUri = result.data?.data
+            // ログに選択されたファイルのパスを表示
+            Log.d("FilePicker", "Selected file: $selectedFileUri")
+            try {
+                context.contentResolver.openInputStream(selectedFileUri!!).use { inputStream ->
+                    val json = inputStream?.bufferedReader().use { it?.readText() }
+                    Log.d("FilePicker", "JSON file loaded successfully")
+                    Log.d("FilePicker", json!!)
+                    data class JsonVersion(
+                        val version: Int
+                    )
+                    val versionInfo = gson.fromJson(json, JsonVersion::class.java)
+                    when (versionInfo.version) {
+                        4 -> {
+                            data class JsonDataV3(
+                                val version: Int,
+                                val songScores: List<SongScore>,
+                                val songs: List<Song>,
+                                val artists: List<Artist>
+                            )
+                            val jsonDataV3 = gson.fromJson(json, JsonDataV3::class.java)
+
+                            // IDが混在するとおかしくなるのでデータベースをクリア
+                            songDao.clearAllSongs()
+                            songScoreDao.clearAllSongScores()
+                            artistDao.clearAllArtists()
+
+                            // データベースにインポート
+                            songDao.insertAll(jsonDataV3.songs)
+                            songScoreDao.insertAll(jsonDataV3.songScores)
+                            artistDao.insertAll(jsonDataV3.artists)
+                        }
+                        else -> {
+                            throw IllegalArgumentException("Unsupported version: ${versionInfo.version}")
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e("FilePicker", "Error loading JSON file", e)
+            }
+        }
+        onClick()
+    }
+
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text("確認") },
+            text = { Text("すべてのデータは失われますがよろしいですか？") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDialog = false
+                        // ファイルピッカーを起動
+                        val intent = Intent(Intent.ACTION_GET_CONTENT).apply {
+                            type = "application/json"
+                        }
+                        filePickerLauncher.launch(intent)
+                    }
+                ) {
+                    Text("はい")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDialog = false }) {
+                    Text("いいえ")
+                }
+            }
+        )
+    }
+
+    Box(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        TextButton(
+            onClick = {
+                showDialog = true
+            },
+            modifier = Modifier.align(Alignment.Center)
+        ) {
+            Text("データのインポート")
+        }
+    }
 }

--- a/app/src/main/java/com/example/karaoke_note/Setting.kt
+++ b/app/src/main/java/com/example/karaoke_note/Setting.kt
@@ -1,0 +1,131 @@
+package com.example.karaoke_note
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingScreen(
+    onNavigateBack: () -> Unit // 戻るボタンが押されたときのコールバック
+) {
+    // 各Switchの状態を管理する
+    var switch1 by remember { mutableStateOf(true) }
+    var switch2 by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("設定") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "戻る"
+                        )
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp)
+        ) {
+            // 1つ目のSwitch設定
+            SettingItemRow(
+                title = "通知を有効にする",
+                checked = switch1,
+                onCheckedChanged = { switch1 = it }
+            )
+
+            HorizontalDivider()
+
+            // 2つ目のSwitch設定
+            SettingItemRow(
+                title = "ダークモードを有効にする",
+                checked = switch2,
+                onCheckedChanged = { switch2 = it }
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // 1つ目のTextButton
+            TextButton(
+                onClick = { /* アカウント設定の処理 */ },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("アカウント設定")
+            }
+
+            HorizontalDivider()
+
+            // 2つ目のTextButton
+            TextButton(
+                onClick = { /* 利用規約の表示処理 */ },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("利用規約")
+            }
+        }
+    }
+}
+
+@Composable
+fun SettingItemRow(
+    title: String,
+    checked: Boolean,
+    onCheckedChanged: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyLarge
+        )
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChanged
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SettingScreenPreview() {
+    // プレビュー用に空のコールバックを渡す
+    SettingScreen(onNavigateBack = {})
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.13.1' apply false
-    id 'com.android.library' version '8.13.1' apply false
-    id 'org.jetbrains.kotlin.android' version '2.2.21' apply false
-    id 'org.jlleitschuh.gradle.ktlint' version '14.0.1'
+    id 'com.android.application' version '9.1.0' apply false
+    id 'com.android.library' version '9.1.0' apply false
+    id 'org.jetbrains.kotlin.android' version '2.3.20' apply false
+    id 'org.jlleitschuh.gradle.ktlint' version '14.2.0'
     id 'io.gitlab.arturbosch.detekt' version '1.23.8'
-    id 'org.jetbrains.kotlin.plugin.compose' version '2.2.21' apply false
-    id 'com.google.devtools.ksp' version "2.3.0" apply false
+    id 'org.jetbrains.kotlin.plugin.compose' version '2.3.20' apply false
+    id 'com.google.devtools.ksp' version '2.3.2' apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,6 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 
+android.disallowKotlinSourceSets=false
+
 #org.gradle.warning.mode=all

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
右上の三点リーダーを設定ボタンに変更し、簡単な設定画面を実装しました。
（ちょっと不安定なのかたまに落ちる）
戻るキーの ON/OFF 切り替え、インポート、エクスポートは機能するはずです。

gradle 周りは ADP 9 に対応させてようとしてしくじった跡です。